### PR TITLE
Feature/g2 soil sticking: Implement graph-based clustering algorithm

### DIFF
--- a/src/chrono_gpu/CMakeLists.txt
+++ b/src/chrono_gpu/CMakeLists.txt
@@ -121,6 +121,8 @@ set(ChronoEngine_GPU_CUDA
     cuda/ChGpu_SMC.cuh
     cuda/ChGpu_SMC_trimesh.cu
     cuda/ChGpu_SMC_trimesh.cuh
+    cuda/ChGpuClustering.cuh
+    cuda/ChGpuClustering.cu
     cuda/ChGpuCollision.cuh
     cuda/ChGpuBoundaryConditions.cuh
     cuda/ChGpuHelpers.cuh

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -47,17 +47,19 @@ enum class CHGPU_FRICTION_MODE { FRICTIONLESS, SINGLE_STEP, MULTI_STEP };
 /// Rolling resistance models -- ELASTIC_PLASTIC not implemented yet.
 enum class CHGPU_ROLLING_MODE { NO_RESISTANCE, SCHWARTZ, ELASTIC_PLASTIC };
 
-enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32};
+enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32, CLUSTER = 64};
 
 /// Clustering algorithm switches
 enum CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1};
 enum CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1};/* BFS -> Breadth-First search */
+
+/// Clustering algorithm switches
 enum CLUSTER_INDEX {GROUND = 0, START = 1};/* number of clusters go up to nSpheres */
 
 // 0 on ANY cluster related switch means no clustering done, all particles group 0.
 // TO DO: Have a different search algorithm than BFS
 
-/// Sphere clustering groups
+/// Sphere groups, core border or noise for clustering, volume inside bucket
 enum SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
 
 #define GET_OUTPUT_SETTING(setting) (this->output_flags & setting)

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -50,19 +50,19 @@ enum class CHGPU_ROLLING_MODE { NO_RESISTANCE, SCHWARTZ, ELASTIC_PLASTIC };
 enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32, CLUSTER = 64};
 
 /// Clustering algorithm switches
-enum CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1};
-enum CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1};/* BFS -> Breadth-First search */
+enum class CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1, PROXIMITY = 2};
+enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1};/* BFS -> Breadth-First search */
 
 /// Clustering algorithm switches
-enum CLUSTER_INDEX {GROUND = 0, START = 1};/* number of clusters go up to nSpheres */
+enum class CLUSTER_INDEX {GROUND = 0, START = 1};/* number of clusters go up to nSpheres */
 
 // 0 on ANY cluster related switch means no clustering done, all particles group 0.
 // TO DO: Have a different search algorithm than BFS
 
 /// Sphere groups, core border or noise for clustering, volume inside bucket
-enum SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
+enum class SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
 
-#define GET_OUTPUT_SETTING(setting) (this->output_flags & setting)
+#define GET_OUTPUT_SETTING(setting) (this->output_flags & static_cast<unsigned int>(setting))
 
 }  // namespace gpu
 }  // namespace chrono

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -59,9 +59,14 @@ enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement faster
 // BFS -> Breadth-First search
 
 /// Cluster index. Ground cluster has most spheres.
-enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, VOLUME = 2, START = 3};/* number of clusters go up to nSpheres */
+/// Noise spheres are part of their own invalid cluster,
+/// Any cluster that contain a VOLUME sphere is part 
+/// of the VOLUME cluster, except if it is the GROUND cluster
+/// Otherwise cluster index increases from START when cluster found 
+enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, VOLUME = 2, START = 3}; /* number of clusters go up to nSpheres */
 
-/// Sphere groups, core border or noise for clustering, volume inside volume
+/// Sphere groups, core border or noise for clustering, volume for inside mesh
+/// a sphere can be a CORE or BORDER of any cluster. 
 enum class SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
 
 #define GET_OUTPUT_SETTING(setting) (this->output_flags & static_cast<unsigned int>(setting))

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -59,7 +59,7 @@ enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement other 
 // BFS -> Breadth-First search
 
 /// Cluster index. Ground cluster has most spheres.
-enum class CLUSTER_INDEX {GROUND = 0, NOCLUSTER = 1, START = 2};/* number of clusters go up to nSpheres */
+enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, START = 2};/* number of clusters go up to nSpheres */
 
 /// Sphere groups, core border or noise for clustering, volume inside bucket
 enum class SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -56,7 +56,7 @@ enum CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1} /* BFS -> Breadth-First search */
 // TO DO: Have a different search algorithm than BFS
 
 /// Sphere clustering groups
-enum SPHERE_GROUP {CORE = 0, BORDER = 1, VOLUME = 2};
+enum SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
 
 #define GET_OUTPUT_SETTING(setting) (this->output_flags & setting)
 

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -56,7 +56,7 @@ enum CHGPU_OUTPUT_FLAGS { ABSV = 1 << 0, VEL_COMPONENTS = 1 << 1,
 // 0 on ANY cluster related switch means no clustering done, all sphere_group and sphere_cluster to 0.
 enum class CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1, PROXIMITY = 2}; /* TODO: Implement proximity graph construction */
 // CONTACT leverages sphere_contact_map to build the graph.
-// PROXIMITY determine contacts by checking if distance between spehre pairs < dbscan_radius
+// PROXIMITY determine contacts by checking if distance between sphere pairs < gbscan_radius; TODO UNTESTED
 
 enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement faster search than BFS
 // BFS -> Breadth-First search

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -53,7 +53,7 @@ enum CHGPU_OUTPUT_FLAGS { ABSV = 1 << 0, VEL_COMPONENTS = 1 << 1,
                           CLUSTER = 1 << 6, ADJACENCY = 1 << 7 };
 
 /// Clustering algorithm switches
-// 0 on ANY cluster related switch means no clustering done, all sphere_group and sphere_cluster to 0.
+// 0 on ANY cluster related switch means no clustering done, all sphere_type and sphere_cluster to 0.
 enum class CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1, PROXIMITY = 2}; /* TODO: Implement proximity graph construction */
 // CONTACT leverages sphere_contact_map to build the graph.
 // PROXIMITY determine contacts by checking if distance between sphere pairs < gbscan_radius; TODO UNTESTED
@@ -70,7 +70,7 @@ enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, VOLUME = 2, START = 3}; /* nu
 
 /// Sphere groups, core border or noise for clustering, volume for inside mesh
 /// a sphere can be a CORE or BORDER of any cluster. 
-enum class SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
+enum class SPHERE_TYPE {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
 
 #define GET_OUTPUT_SETTING(setting) (this->output_flags & static_cast<unsigned int>(setting))
 

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -50,8 +50,10 @@ enum class CHGPU_ROLLING_MODE { NO_RESISTANCE, SCHWARTZ, ELASTIC_PLASTIC };
 enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32};
 
 /// Clustering algorithm switches
-enum CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1}
-enum CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1} /* BFS -> Breadth-First search */
+enum CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1};
+enum CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1};/* BFS -> Breadth-First search */
+enum CLUSTER_INDEX {GROUND = 0, START = 1};/* number of clusters go up to nSpheres */
+
 // 0 on ANY cluster related switch means no clustering done, all particles group 0.
 // TO DO: Have a different search algorithm than BFS
 

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -49,8 +49,14 @@ enum class CHGPU_ROLLING_MODE { NO_RESISTANCE, SCHWARTZ, ELASTIC_PLASTIC };
 
 enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32};
 
+/// Clustering algorithm switches
+enum CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1}
+enum CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1} /* BFS -> Breadth-First search */
+// 0 on ANY cluster related switch means no clustering done, all particles group 0.
+// TO DO: Have a different search algorithm than BFS
+
 /// Sphere clustering groups
-enum SPHERE_GROUP {GROUND = 0, VOLUME = 1, AIRBORNE = 2};
+enum SPHERE_GROUP {CORE = 0, BORDER = 1, VOLUME = 2};
 
 #define GET_OUTPUT_SETTING(setting) (this->output_flags & setting)
 

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -68,7 +68,7 @@ enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement faster
 /// Otherwise cluster index increases from START when cluster found 
 enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, VOLUME = 2, START = 3}; /* number of clusters go up to nSpheres */
 
-/// Sphere groups, core border or noise for clustering, volume for inside mesh
+/// Sphere type, CORE BORDER or NOISE for clustering, VOLUME for inside mesh
 /// a sphere can be a CORE or BORDER of any cluster. 
 enum class SPHERE_TYPE {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
 

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -50,14 +50,16 @@ enum class CHGPU_ROLLING_MODE { NO_RESISTANCE, SCHWARTZ, ELASTIC_PLASTIC };
 enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32, CLUSTER = 64};
 
 /// Clustering algorithm switches
-enum class CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1, PROXIMITY = 2};
-enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1};/* BFS -> Breadth-First search */
-
-/// Clustering algorithm switches
-enum class CLUSTER_INDEX {GROUND = 0, START = 1};/* number of clusters go up to nSpheres */
-
 // 0 on ANY cluster related switch means no clustering done, all particles group 0.
-// TO DO: Have a different search algorithm than BFS
+enum class CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1, PROXIMITY = 2}; /* TODO: Implement proximity graph construction */
+// CONTACT leverages DetermineContactPairs to build the graph.
+// PROXIMITY determine contacts by checking if distance between spehre pairs < some radius
+
+enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement other search than BFS
+// BFS -> Breadth-First search
+
+/// Cluster index. Ground cluster has most spheres.
+enum class CLUSTER_INDEX {GROUND = 0, START = 1};/* number of clusters go up to nSpheres */
 
 /// Sphere groups, core border or noise for clustering, volume inside bucket
 enum class SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -50,12 +50,12 @@ enum class CHGPU_ROLLING_MODE { NO_RESISTANCE, SCHWARTZ, ELASTIC_PLASTIC };
 enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32, CLUSTER = 64, ADJACENCY = 128 };
 
 /// Clustering algorithm switches
-// 0 on ANY cluster related switch means no clustering done, all particles group 0.
+// 0 on ANY cluster related switch means no clustering done, all sphere_group and sphere_cluster to 0.
 enum class CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1, PROXIMITY = 2}; /* TODO: Implement proximity graph construction */
-// CONTACT leverages DetermineContactPairs to build the graph.
-// PROXIMITY determine contacts by checking if distance between spehre pairs < some radius
+// CONTACT leverages sphere_contact_map to build the graph.
+// PROXIMITY determine contacts by checking if distance between spehre pairs < dbscan_radius
 
-enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement other search than BFS
+enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement faster search than BFS
 // BFS -> Breadth-First search
 
 /// Cluster index. Ground cluster has most spheres.

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -59,9 +59,9 @@ enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement faster
 // BFS -> Breadth-First search
 
 /// Cluster index. Ground cluster has most spheres.
-enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, BUCKET = 2, START = 3};/* number of clusters go up to nSpheres */
+enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, VOLUME = 2, START = 3};/* number of clusters go up to nSpheres */
 
-/// Sphere groups, core border or noise for clustering, volume inside bucket
+/// Sphere groups, core border or noise for clustering, volume inside volume
 enum class SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
 
 #define GET_OUTPUT_SETTING(setting) (this->output_flags & static_cast<unsigned int>(setting))

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -49,7 +49,7 @@ enum class CHGPU_ROLLING_MODE { NO_RESISTANCE, SCHWARTZ, ELASTIC_PLASTIC };
 
 enum CHGPU_OUTPUT_FLAGS { ABSV = 1 << 0, VEL_COMPONENTS = 1 << 1,
                           FIXITY = 1 << 2, ANG_VEL_COMPONENTS = 1 << 3,
-                          FORCE_COMPONENTS = 1 << 4, GROUP = 1 << 5,
+                          FORCE_COMPONENTS = 1 << 4, TYPE = 1 << 5,
                           CLUSTER = 1 << 6, ADJACENCY = 1 << 7 };
 
 /// Clustering algorithm switches

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -59,7 +59,7 @@ enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement other 
 // BFS -> Breadth-First search
 
 /// Cluster index. Ground cluster has most spheres.
-enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, START = 2};/* number of clusters go up to nSpheres */
+enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, BUCKET = 2, START = 3};/* number of clusters go up to nSpheres */
 
 /// Sphere groups, core border or noise for clustering, volume inside bucket
 enum class SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -47,7 +47,7 @@ enum class CHGPU_FRICTION_MODE { FRICTIONLESS, SINGLE_STEP, MULTI_STEP };
 /// Rolling resistance models -- ELASTIC_PLASTIC not implemented yet.
 enum class CHGPU_ROLLING_MODE { NO_RESISTANCE, SCHWARTZ, ELASTIC_PLASTIC };
 
-enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32, CLUSTER = 64};
+enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32, CLUSTER = 64, ADJACENCY = 128 };
 
 /// Clustering algorithm switches
 // 0 on ANY cluster related switch means no clustering done, all particles group 0.
@@ -59,7 +59,7 @@ enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement other 
 // BFS -> Breadth-First search
 
 /// Cluster index. Ground cluster has most spheres.
-enum class CLUSTER_INDEX {GROUND = 0, START = 1};/* number of clusters go up to nSpheres */
+enum class CLUSTER_INDEX {GROUND = 0, NOCLUSTER = 1, START = 2};/* number of clusters go up to nSpheres */
 
 /// Sphere groups, core border or noise for clustering, volume inside bucket
 enum class SPHERE_GROUP {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -47,7 +47,10 @@ enum class CHGPU_FRICTION_MODE { FRICTIONLESS, SINGLE_STEP, MULTI_STEP };
 /// Rolling resistance models -- ELASTIC_PLASTIC not implemented yet.
 enum class CHGPU_ROLLING_MODE { NO_RESISTANCE, SCHWARTZ, ELASTIC_PLASTIC };
 
-enum CHGPU_OUTPUT_FLAGS { ABSV = 1, VEL_COMPONENTS = 2, FIXITY = 4, ANG_VEL_COMPONENTS = 8, FORCE_COMPONENTS = 16, GROUP = 32, CLUSTER = 64, ADJACENCY = 128 };
+enum CHGPU_OUTPUT_FLAGS { ABSV = 1 << 0, VEL_COMPONENTS = 1 << 1,
+                          FIXITY = 1 << 2, ANG_VEL_COMPONENTS = 1 << 3,
+                          FORCE_COMPONENTS = 1 << 4, GROUP = 1 << 5,
+                          CLUSTER = 1 << 6, ADJACENCY = 1 << 7 };
 
 /// Clustering algorithm switches
 // 0 on ANY cluster related switch means no clustering done, all sphere_group and sphere_cluster to 0.

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -9,9 +9,11 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 //
-// Contains collision helper functions from ChNarrowphaseR
+// Contains functions that separated soil particles into clusters
+// Reference: Andrade, Guilherme, et al. "G-dbscan: A gpu accelerated algorithm 
+// for density-based clustering." Procedia Computer Science 18 (2013): 369-378.
 // =============================================================================
-// Authors: Conlain Kelly, Nic Olsen, Dan Negrut
+// Authors: Gabriel Taillon
 // =============================================================================
 
 #include "chrono_gpu/ChGpuDefines.h"

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -96,7 +96,8 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
             // visit all spheres connected to sphere i in parallel
             do {
                 // find and visit border points, establishing the cluster
-                ClusterSearchBFSKernel<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
+                ClusterSearchBFSKernel<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
+                    nSpheres,
                     adj_num,
                     adj_offset,
                     adj_list,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -125,8 +125,10 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
 
             // find if any sphere was tagged in the VOLUME type
             FindVolumeCluster<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
-                nSpheres, d_visited,
-                d_in_volume, sphere_data->sphere_type);
+                nSpheres,
+                d_visited,
+                d_in_volume,
+                sphere_data->sphere_type);
             // Sum number of particles in d_in_volume into h_in_volume_num
             void *d_temp_storage = NULL;
             size_t temp_storage_bytes = 0;
@@ -202,10 +204,9 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
 }  // namespace chrono
 
 /// Uses sphere_contact_map to construct adjacency lists for clustering
-__host__ void ConstructGraphByContact(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres) {
+__host__ void ConstructGraphByContact(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                      ChSystemGpu_impl::GranParamsPtr gran_params,
+                                      unsigned int nSpheres) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
     ComputeAdjNumByContact<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data,
@@ -230,10 +231,11 @@ __host__ void ConstructGraphByContact(
 /// Identifies core, border and noise points in h_clusters.
 /// min_pts: minimal number of points for a h_cluster
 /// radius: proximity radius, points inside can form a h_cluster
-__host__ void ConstructGraphByProximity(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres, size_t min_pts, float radius) {
+__host__ void ConstructGraphByProximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                        ChSystemGpu_impl::GranParamsPtr gran_params,
+                                        unsigned int nSpheres,
+                                        size_t min_pts,
+                                        float radius) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
     /// compute all adjacent spheres inside radius
@@ -256,17 +258,17 @@ __host__ void ConstructGraphByProximity(
 /// Identifies core, border and noise points in h_clusters.
 /// Searches using a parallel Breadth-First search
 /// min_pts: minimal number of points for a cluster
-__host__ void GdbscanSearchGraph(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres, size_t min_pts) {
+__host__ void GdbscanSearchGraph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                 ChSystemGpu_impl::GranParamsPtr gran_params,
+                                 unsigned int nSpheres,
+                                 size_t min_pts) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
     unsigned int ** h_clusters = ClusterSearchBFS(nSpheres, sphere_data,
-                                        sphere_data->adj_num,
-                                        sphere_data->adj_offset,
-                                        sphere_data->adj_list,
-                                        sphere_data->sphere_type);
+                                                  sphere_data->adj_num,
+                                                  sphere_data->adj_offset,
+                                                  sphere_data->adj_list,
+                                                  sphere_data->sphere_type);
     unsigned int cluster_num = h_clusters[0][0];
     unsigned int sphere_num_in_cluster;
     unsigned int biggest_cluster_size = 1;
@@ -295,8 +297,10 @@ __host__ void GdbscanSearchGraph(
         gpuErrchk(cudaDeviceSynchronize());
     }
 
-    GdbscanFinalClusterFromType<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
-            sphere_data->sphere_cluster, sphere_data->sphere_type);
+    GdbscanFinalClusterFromType<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
+        nSpheres,
+        sphere_data->sphere_cluster,
+        sphere_data->sphere_type);
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaDeviceSynchronize());
 

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -31,12 +31,11 @@ namespace gpu {
 /// Neighbors set in d_borders, visited on next call
 /// Call until no border spheres i.e. nothing true in d_borders
 static __global__ void ClusterSearchBFSKernel(unsigned int nSpheres,
-                        unsigned int * adj_num,
-                        unsigned int * adj_start,
-                        unsigned int * adj_list,
-                        bool * d_borders, 
-                        bool * d_visited) {
-
+                                              unsigned int * adj_num,
+                                              unsigned int * adj_start,
+                                              unsigned int * adj_list,
+                                              bool * d_borders,
+                                              bool * d_visited) {
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     if (mySphereID < nSpheres) { 
@@ -62,11 +61,11 @@ static __global__ void ClusterSearchBFSKernel(unsigned int nSpheres,
 /// h_clusters[M][N] -> Nth point in Mth h_cluster
 /// return pointer to h_clusters: array of pointers to arrays of variable length
 static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
-                        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                        unsigned int* adj_num,
-                        unsigned int* adj_start,
-                        unsigned int* adj_list,
-                        SPHERE_GROUP* sphere_group) {
+                                                 ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                                 unsigned int* adj_num,
+                                                 unsigned int* adj_start,
+                                                 unsigned int* adj_list,
+                                                 SPHERE_GROUP* sphere_group) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
     cudaMemset(sphere_data->sphere_cluster, static_cast<unsigned int>(chrono::gpu::CLUSTER_INDEX::GROUND), sizeof(*sphere_data->sphere_cluster) * nSpheres);
@@ -216,9 +215,9 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
 /// UNTESTED
 /// counts number of adjacent spheres by proximity.
 static __global__ void ComputeAdjNumByProximity(
-                        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                        ChSystemGpu_impl::GranParamsPtr gran_params,
-                        unsigned int nSpheres, float radius) {
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+        ChSystemGpu_impl::GranParamsPtr gran_params,
+        unsigned int nSpheres, float radius) {
 
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
@@ -253,9 +252,10 @@ static __global__ void ComputeAdjNumByProximity(
 
 /// UNTESTED
 /// computes adj_list from proximity using known adj_num and adj_start
-static __global__ void ComputeAdjListByProximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres, float radius) {
+static __global__ void ComputeAdjListByProximity(
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+       ChSystemGpu_impl::GranParamsPtr gran_params,
+       unsigned int nSpheres, float radius) {
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     unsigned int otherSphereID;
@@ -296,12 +296,14 @@ static __global__ void ComputeAdjListByProximity(ChSystemGpu_impl::GranSphereDat
 
 
 /// UNTESTED
-/// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
+/// G-DBSCAN; density-based h_clustering algorithm.
+/// Identifies core, border and noise points in h_clusters.
 /// min_pts: minimal number of points for a h_cluster
 /// radius: proximity radius, points inside can form a h_cluster
-__host__ void GdbscanConstructGraph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres, size_t min_pts, float radius) {
+__host__ void GdbscanConstructGraph(
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+        ChSystemGpu_impl::GranParamsPtr gran_params,
+        unsigned int nSpheres, size_t min_pts, float radius) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
     /// compute all adjacent spheres inside radius
@@ -317,9 +319,10 @@ __host__ void GdbscanConstructGraph(ChSystemGpu_impl::GranSphereDataPtr sphere_d
 /// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.<
 /// Searches using a parallel Breadth-First search
 /// min_pts: minimal number of points for a cluster
-__host__ void GdbscanSearchGraph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres, size_t min_pts) {
+__host__ void GdbscanSearchGraph(
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+        ChSystemGpu_impl::GranParamsPtr gran_params,
+        unsigned int nSpheres, size_t min_pts) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
     unsigned int ** h_clusters = ClusterSearchBFS(nSpheres, sphere_data,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -25,89 +25,89 @@
 namespace chrono {
 namespace gpu {
 
-/// UNTESTED
-/// counts number of adjacent spheres by proximity.
-static __global__ void construct_adj_num_start_by_proximity(
-                        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                        ChSystemGpu_impl::GranParamsPtr gran_params,
-                        unsigned int nSpheres, float radius) {
+// /// UNTESTED
+// /// counts number of adjacent spheres by proximity.
+// static __global__ void construct_adj_num_start_by_proximity(
+//                         ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+//                         ChSystemGpu_impl::GranParamsPtr gran_params,
+//                         unsigned int nSpheres, float radius) {
 
-    // my sphere ID, we're using a 1D thread->sphere map
-    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    unsigned int otherSphereID;
+//     // my sphere ID, we're using a 1D thread->sphere map
+//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+//     unsigned int otherSphereID;
 
-    unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
-    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
-    unsigned int otherSD;
+//     unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
+//     unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
+//     unsigned int otherSD;
 
-    int3 mySphere_pos_local, otherSphere_pos_local;
-    double3 mySphere_pos_global, otherSphere_pos_local, distance;
+//     int3 mySphere_pos_local, otherSphere_pos_local;
+//     double3 mySphere_pos_global, otherSphere_pos_local, distance;
 
-    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
-            sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
-    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
+//     mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
+//             sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
+//     mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
 
-    if (mySphereID < nSpheres) {
-    /// find all spheres inside the radius around mySphere
-        for (size_t i = 0; (i < nSpheres); i++) {
-            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
-            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
-            distance = mySphere_pos_global - otherSphere_pos_global;
-                if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
-                    adj_num[i]++;
-                    adj_num[mySphereID]++;
-                }
-            adj_start[i+1]++;
-            /// perform an inclusive sum. start index of subsequent vertices depend on all previous indices.
-            void * d_temp_storage = NULL;
-            size_t temp_storage_bytesize = 0;
-            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
-            gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytesize));
-            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
-        }
-    }
-}
+//     if (mySphereID < nSpheres) {
+//     /// find all spheres inside the radius around mySphere
+//         for (size_t i = 0; (i < nSpheres); i++) {
+//             otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
+//             sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
+//             otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
+//             distance = mySphere_pos_global - otherSphere_pos_global;
+//                 if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
+//                     adj_num[i]++;
+//                     adj_num[mySphereID]++;
+//                 }
+//             adj_start[i+1]++;
+//             /// perform an inclusive sum. start index of subsequent vertices depend on all previous indices.
+//             void * d_temp_storage = NULL;
+//             size_t temp_storage_bytesize = 0;
+//             cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+//             gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytesize));
+//             cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+//         }
+//     }
+// }
 
-/// UNTESTED
-/// computes adj_list from proximity using known adj_num and adj_start
-static __global__ void construct_adj_list_by_proximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres, float radius,
-                                           unsigned int* adj_num,
-                                           unsigned int* adj_start,
-                                           unsigned int* adj_list) {
-    // my sphere ID, we're using a 1D thread->sphere map
-    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    unsigned int otherSphereID;
+// /// UNTESTED
+// /// computes adj_list from proximity using known adj_num and adj_start
+// static __global__ void construct_adj_list_by_proximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+//                                            ChSystemGpu_impl::GranParamsPtr gran_params,
+//                                            unsigned int nSpheres, float radius,
+//                                            unsigned int* adj_num,
+//                                            unsigned int* adj_start,
+//                                            unsigned int* adj_list) {
+//     // my sphere ID, we're using a 1D thread->sphere map
+//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+//     unsigned int otherSphereID;
 
-    unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
-    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
-    unsigned int otherSD;
+//     unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
+//     unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
+//     unsigned int otherSD;
 
-    unsigned int vertex_start = adj_start[mySphereID];
-    unsigned int adjacency_num = 0;
+//     unsigned int vertex_start = adj_start[mySphereID];
+//     unsigned int adjacency_num = 0;
 
-    int3 mySphere_pos_local, otherSphere_pos_local;
-    double3 mySphere_pos_global, otherSphere_pos_local;
+//     int3 mySphere_pos_local, otherSphere_pos_local;
+//     double3 mySphere_pos_global, otherSphere_pos_global;
 
-    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
-            sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
-    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
+//     mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
+//             sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
+//     mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
 
-    if (mySphereID < nSpheres) {
-        for (size_t i = 0; (i < nSpheres); i++) {
-            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
-            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
-            distance = mySphere_pos_global - otherSphere_pos_global;
-            if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
-                adj_list[vertex_start + adjacency_num] = i;
-            }
-        }                  
-    }
-    assert(adjacency_num == vertex_adjacency_num[mySphereID]);
-}
+//     if (mySphereID < nSpheres) {
+//         for (size_t i = 0; (i < nSpheres); i++) {
+//             otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
+//             sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
+//             otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
+//             distance = mySphere_pos_global - otherSphere_pos_global;
+//             if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
+//                 adj_list[vertex_start + adjacency_num] = i;
+//             }
+//         }                  
+//     }
+//     assert(adjacency_num == vertex_adjacency_num[mySphereID]);
+// }
 
 /// All spheres with > minPts contacts are core, other points maybe be border points.
 static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -310,6 +310,10 @@ __host__ void GdbscanSearchGraph(ChSystemGpu_impl::GranSphereDataPtr sphere_data
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaDeviceSynchronize());
 
+    SetVolumeSphereGroup<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data,nSpheres);
+    gpuErrchk(cudaPeekAtLastError());
+    gpuErrchk(cudaDeviceSynchronize());
+
     for (size_t i = 0; i < cluster_num; i++) {
         free(h_clusters[i]);
     }

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -69,6 +69,10 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
                         SPHERE_GROUP* sphere_group) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
+    cudaMemset(sphere_data->sphere_cluster, static_cast<unsigned int>(chrono::gpu::CLUSTER_INDEX::GROUND), sizeof(*sphere_data->sphere_cluster) * nSpheres);
+    gpuErrchk(cudaPeekAtLastError());
+    gpuErrchk(cudaDeviceSynchronize());
+
     /// CLUSTERS REPRESENTATION IN MEMORY
     /// clusters, array of points to arrays of variable lengths, with lengths at [0]
     unsigned int * h_cluster;

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -97,7 +97,7 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
     bool * d_visited; // [mySphereID] -> was vertex d_visited during BFS_kernel?
     bool * h_visited; // [mySphereID] -> host of d_visited
     bool * h_searched; // [mySphereID] -> was vertex searched before?
-    bool * d_in_bucket; // [mySphereID] -> was vertex searched before?
+    bool * d_in_bucket; // [mySphereID] -> is particle inside the bucket?
     gpuErrchk(cudaMalloc((void**)&d_borders, sizeof(*d_borders) * nSpheres));
     gpuErrchk(cudaMalloc((void**)&d_visited, sizeof(*d_visited) * nSpheres));
     gpuErrchk(cudaMalloc((void**)&d_in_bucket, sizeof(*d_in_bucket) * nSpheres));

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -96,9 +96,12 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
             // visit all spheres connected to sphere i in parallel
             do {
                 // find and visit border points, establishing the cluster
-                ClusterSearchBFSKernel<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
-                    nSpheres, adj_num, adj_offset, adj_list,
-                    d_borders, d_visited);
+                ClusterSearchBFSKernel<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
+                    adj_num,
+                    adj_offset,
+                    adj_list,
+                    d_borders,
+                    d_visited);
                 gpuErrchk(cudaPeekAtLastError());
                 gpuErrchk(cudaDeviceSynchronize());
                 // Allocate temporary storage
@@ -121,9 +124,9 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
             } while ((*h_border_num) > 0);
 
             // find if any sphere was tagged in the VOLUME type
-            FindVolumeCluster<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
-               d_visited, d_in_volume,
-               sphere_data->sphere_type);
+            FindVolumeCluster<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
+                nSpheres, d_visited,
+                d_in_volume, sphere_data->sphere_type);
             // Sum number of particles in d_in_volume into h_in_volume_num
             void *d_temp_storage = NULL;
             size_t temp_storage_bytes = 0;

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -1,0 +1,324 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2019 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+//
+// Contains collision helper functions from ChNarrowphaseR
+// =============================================================================
+// Authors: Conlain Kelly, Nic Olsen, Dan Negrut
+// =============================================================================
+
+#pragma once
+
+#include "chrono_gpu/ChGpuDefines.h"
+#include "chrono_gpu/physics/ChSystemGpu_impl.h"
+#include "chrono_gpu/cuda/ChCudaMathUtils.cuh"
+#include "chrono_gpu/cuda/ChGpuHelpers.cuh"
+#include "chrono_gpu/cuda/ChGpuClustering.cuh"
+
+namespace chrono {
+namespace gpu {
+
+/// UNTESTED
+/// counts number of adjacent spheres by proximity.
+static __global__ void construct_adj_num_start_by_proximity(
+                        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                        ChSystemGpu_impl::GranParamsPtr gran_params,
+                        unsigned int nSpheres, float radius) {
+
+    // my sphere ID, we're using a 1D thread->sphere map
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+    unsigned int otherSphereID;
+
+    unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
+    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
+    unsigned int otherSD;
+
+    int3 mySphere_pos_local, otherSphere_pos_local;
+    double3 mySphere_pos_global, otherSphere_pos_local, distance;
+
+    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
+            sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
+    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
+
+    if (mySphereID < nSpheres) {
+    /// find all spheres inside the radius around mySphere
+        for (size_t i = 0; (i < nSpheres); i++) {
+            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
+            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
+            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
+            distance = mySphere_pos_global - otherSphere_pos_global;
+                if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
+                    adj_num[i]++;
+                    adj_num[mySphereID]++;
+                }
+            adj_start[i+1]++;
+            /// perform an inclusive sum. start index of subsequent vertices depend on all previous indices.
+            void * d_temp_storage = NULL;
+            size_t temp_storage_bytesize = 0;
+            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+            gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytesize));
+            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+        }
+    }
+}
+
+/// UNTESTED
+/// computes adj_list from proximity using known adj_num and adj_start
+static __global__ void construct_adj_list_by_proximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                           ChSystemGpu_impl::GranParamsPtr gran_params,
+                                           unsigned int nSpheres, float radius,
+                                           unsigned int* adj_num,
+                                           unsigned int* adj_start,
+                                           unsigned int* adj_list) {
+    // my sphere ID, we're using a 1D thread->sphere map
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+    unsigned int otherSphereID;
+
+    unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
+    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
+    unsigned int otherSD;
+
+    unsigned int vertex_start = adj_start[mySphereID];
+    unsigned int adjacency_num = 0;
+
+    int3 mySphere_pos_local, otherSphere_pos_local;
+    double3 mySphere_pos_global, otherSphere_pos_local;
+
+    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
+            sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
+    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
+
+    if (mySphereID < nSpheres) {
+        for (size_t i = 0; (i < nSpheres); i++) {
+            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
+            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
+            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
+            distance = mySphere_pos_global - otherSphere_pos_global;
+            if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
+                adj_list[vertex_start + adjacency_num] = i;
+            }
+        }                  
+    }
+    assert(adjacency_num == vertex_adjacency_num[mySphereID]);
+}
+
+/// All spheres with > minPts contacts are core, other points maybe be border points.
+static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,
+                                           unsigned int* adj_num,
+                                           SPHERE_GROUP* sphere_group,
+                                           unsigned int minPts) {
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+    sphere_group[mySphereID] = adj_num[mySphereID] > minPts ? SPHERE_GROUP::CORE : SPHERE_GROUP::NOISE;
+}
+
+/// computes h_cluster by breadth first search
+/// return pointer to h_clusters: array of pointers to arrays of variable length
+static __host__ unsigned int * cluster_search_BFS(unsigned int nSpheres,
+                        unsigned int* adj_num,
+                        unsigned int* adj_start,
+                        unsigned int* adj_list,
+                        SPHERE_GROUP* sphere_group) {
+    unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
+
+    /// CLUSTERS REPRESENTATION IN MEMORY
+    /// ALTERNATIVE 1:
+    /// clusters, array of points to arrays of variable lengths, with lengths at [0]
+    unsigned int * h_cluster;
+    unsigned int h_cluster_num = 1;
+    unsigned int ** h_clusters;
+    h_clusters = (unsigned int *)malloc(sizeof(*h_clusters) * (nSpheres+1)); // at worst, there will be nSpheres h_clusters
+    h_clusters[0] = (unsigned int *)malloc(sizeof(**h_clusters)); // number of h_clusters at h_clusters[0][0]
+    /// h_clusters[0][0] -> number of pointers/h_clusters
+    /// h_clusters[M][0] -> size of the Mth h_cluster
+    /// h_clusters[M][N] -> Nth point in Mth h_cluster
+
+    /// CLUSTERS REPRESENTATION IN MEMORY
+    /// ALTERNATIVE 2:
+    // /// cluster_list/cluster_num/sphere_in_cluster_num similar to adj_num, adj_list (annoying to ouput)
+    // unsigned int * h_cluster_list;
+    // unsigned int h_cluster_num; /// number of spheres in each cluster
+    // unsigned int * h_sphere_num_in_cluster; /// number of spheres in each cluster
+    // unsigned int * h_cluster_start; /// index where cluster list starts in h_cluster_list
+    // h_cluster_list = (unsigned int *)malloc(sizeof(*h_cluster_list) * nSpheres); // there is only nSpheres in ALL clusters
+    // h_cluster_start = (unsigned int *)malloc(sizeof(*h_cluster_start) * nSpheres); // at worst, there will be nSpheres h_clusters
+    // h_sphere_num_in_cluster = (unsigned int *)malloc(sizeof(*h_sphere_num_in_cluster) * nSpheres); // at worst, there will be nSpheres h_clusters
+
+    bool * d_borders; // [mySphereID] -> is vertex a border?
+    bool * d_visited; // [mySphereID] -> was vertex d_visited during BFS_kernel?
+    bool * h_visited; // [mySphereID] -> host of d_visited
+    bool * h_searched; // [mySphereID] -> was vertex searched before?
+    unsigned int * d_border_num; // number of remaining border vertices to search in BFS_kernel
+    unsigned int * h_border_num; // number of remaining border vertices to search in BFS_kernl
+    gpuErrchk(cudaMalloc((void**)&d_borders, sizeof(*d_borders) * nSpheres));
+    gpuErrchk(cudaMalloc((void**)&d_visited, sizeof(*d_visited) * nSpheres));
+    gpuErrchk(cudaMalloc((void**)&d_border_num, sizeof(*d_border_num));
+    h_visited = (bool *)calloc(sizeof(*h_visited), nSpheres);
+    h_searched = (bool *)calloc(sizeof(*h_searched), nSpheres);
+    SPHERE_GROUP h_current_group;
+
+    for (size_t i = 0; i < nSpheres; i++) {
+        gpuErrchk(cudaMemcpy(h_current_group, (sphere_data->sphere_group + i), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
+        /// find the next h_cluster, at the first sphere not yet searched.
+        if ((!h_searched[i]) && (h_current_group == SPHERE_GROUP::CORE)) {
+            gpuErrchk(cudaMemset(&d_borders, false, sizeof(*d_borders) * nSpheres));
+            gpuErrchk(cudaMemset(&d_visited, false, sizeof(*d_visited) * nSpheres));
+            gpuErrchk(cudaMemset(&(d_border_num), 1, sizeof(*d_border_num)));
+            gpuErrchk(cudaMemset(&(d_borders + i), true, sizeof(*d_borders)));
+            h_searched[i] = true;
+
+            do {
+            h_clustering_search_BFS_kernel<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
+                radius, adj_num, adj_start, adj_list,
+                d_borders, d_visited, d_border_num);
+                gpuErrchk(cudaMemcpy(h_border_num, d_border_num, sizeof(*d_border_num)), cudaMemcpyDeviceToHost);
+            } while (h_border_num > 0);
+            
+            gpuErrchk(cudaMemcpy(h_visited, d_visited, sizeof(*d_visited)* nSpheres, cudaMemcpyDeviceToHost);
+            h_cluster = (unsigned int *)malloc(sizeof(*h_cluster) * (nSpheres + 1));
+            // h_cluster[0] is its size, so it length nSpheres + 1
+            for (size_t j = 0; i < nSpheres; j++) {
+                if (h_visited[j]) {
+                    h_searched[j] = true;
+                    h_cluster[h_cluster[0]++] = j;
+                    gpuErrchk(cudaMemcpy(&h_current_group, &(sphere_data->sphere_group + j), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
+                    if (h_current_group != SPHERE_GROUP::CORE) {
+                       gpuErrchk(cudaMemset(&(sphere_data->sphere_group + j), SPHERE_GROUP::BORDER, sizeof(*sphere_data->sphere_group)));
+                    }
+                }
+            }
+            h_cluster = (unsigned int *)realloc(h_cluster, sizeof(*h_cluster) * (h_cluster[0]));
+            h_clusters[h_cluster_num] = h_cluster;
+            h_clusters[0][0] = ++h_cluster_num; // h_clusters size is number of clusters + 1 cause it includes its length 
+        }
+    }
+    h_clusters = (unsigned int *)realloc(h_clusters, sizeof(*h_clusters) * (h_clusters[0][0]));
+
+    free(h_visited);
+    free(h_searched);
+    free(h_border_num);
+    free(h_current_group);
+    gpuErrchk(cudaFree(d_borders));
+    gpuErrchk(cudaFree(d_border_num));
+    gpuErrchk(cudaFree(d_visited));
+    return(h_clusters);
+}
+
+// /// computes h_cluster by breadth first search
+// static __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
+//                         unsigned int * adj_num
+//                         unsigned int * adj_start
+//                         unsigned int * adj_list,
+//                         bool * d_borders, 
+//                         bool * d_visited,
+//                         unsigned int * d_border_num) {
+
+//     // my sphere ID, we're using a 1D thread->sphere map
+//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+//     unsigned int neighborSphereID;
+
+//     if (d_visited[mySphereID]) {
+//         d_visited[mySphereID] = true;
+//         d_borders[mySphereID] = false;
+//         atomicAdd(d_border_num, -1);
+//         unsigned int start = adj_start[mySphereID];
+//         unsigned int end = adj_start[mySphereID] + vertex_adjacency_num[mySphereID];
+//         for (size_t i = start; i < end; i++) {
+//             unsigned int neighborSphereID = adj_list[i];
+//             if (!d_visited[neighborSphereID]) {
+//                 border[neighborSphereID] = true;
+//                 atomicAdd(d_border_num, 1);
+//             }
+//         }
+//     }
+// }
+
+// /// UNTESTED
+// /// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
+// /// SEARCH STEP
+// /// min_pts: minimal number of points for a h_cluster
+// /// radius: proximity radius, points inside can form a h_cluster
+// static __host__ void gdbscan_construct_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+//                                            ChSystemGpu_impl::GranParamsPtr gran_params,
+//                                            unsigned int nSpheres, size_t min_pts, float radius) {
+//     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
+
+//     /// 2 steps:
+//     ///     1- compute all adjacent spheres inside radius
+//     construct_adj_num_start_by_proximity<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data, gran_params, nSpheres,
+//             radius, adj_num, adj_start);
+
+//     ///     2- compute adjacency list
+//     construct_adj_list_by_proximity<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data, gran_params, nSpheres,
+//             radius, adj_num, adj_start, adj_list);
+// }
+
+// static __global__ void update_cluster_group(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+//                                            ChSystemGpu_impl::GranParamsPtr gran_params,
+//                                            unsigned int sphere_num_in_cluster,
+//                                            unsigned int cluster_id,
+//                                            unsigned int * cluster) {
+//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+//     for (size_t i = 0; i < sphere_num_in_cluster; i++) { 
+//         if (cluster[i] == mySphereID) {
+//             sphere_data->sphere_cluster = cluster_id;
+//         }
+//     }
+// }
+
+/// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
+/// min_pts: minimal number of points for a cluster
+static __host__ void gdbscan_search_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                           ChSystemGpu_impl::GranParamsPtr gran_params,
+                                           unsigned int nSpheres, size_t min_pts) {
+    unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
+
+    init_sphere_group_gdbscan<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
+                sphere_data->adj_num, sphere_data->sphere_group, minPts);
+
+    unsigned int h_clusters * cluster_search_BFS(nSpheres, sphere_data->adj_num,
+                                        sphere_data->adj_start,
+                                        sphere_data->adj_list,
+                                        sphere_data->sphere_group);
+
+    unsigned int * d_cluster;
+    unsigned int cluster_num = h_clusters[0][0];
+    unsigned int sphere_num_in_cluster;
+    unsigned int biggest_cluster_size = 1;
+    unsigned int biggest_cluster_id = 1;
+
+    // find biggest cluster id
+    for (size_t i = 0; i <  cluster_num, i++) {// expect low number of clusters, 1 most of the time, maybe 2-3 otherwise.
+        sphere_num_in_cluster = h_clusters[i][0];
+        if (sphere_num_in_cluster > biggest_cluster_size) {
+            biggest_cluster_size = sphere_num_in_cluster;
+            biggest_cluster_id = i;
+        }
+    }    
+
+    // tag each sphere to a cluster_group
+    for (size_t i = 1; i < h_cluster_num; i++) {// expect low number of clusters, 1 most of the time, maybe 2-3 otherwise.
+        unsigned int cluster_id = (biggest_cluster == i) ? CLUSTER_GROUP::GROUND : i;
+        gpuErrchk(cudaMalloc(&d_cluster, h_clusters[i][0]));
+        gpuErrchk(cudaMemcpy(d_cluster, h_clusters[i] + 1, sizeof(*d_cluster) * h_clusters[i][0]));
+        sphere_num_in_cluster = h_clusters[i][0];
+        update_cluster_group<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data,
+                                            gran_params, sphere_num_in_cluster,
+                                            cluster_id, d_cluster);
+        gpuErrchk(cudaFree(d_cluster));
+    }
+
+    for (size_t i = 0; i < h_clusters[0][0]) {
+        free(h_clusters[i]);
+    }
+    free(h_clusters);
+}
+
+}  // namespace gpu
+}  // namespace chrono

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -292,7 +292,7 @@ __host__ void GdbscanSearchGraph(
         gpuErrchk(cudaDeviceSynchronize());
     }
 
-    GdbscanFinalClusterFromGroup<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
+    GdbscanFinalClusterFromType<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
             sphere_data->sphere_cluster, sphere_data->sphere_type);
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaDeviceSynchronize());

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -211,7 +211,7 @@ __host__ void ConstructGraphByContact(
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaDeviceSynchronize());
 
-    ComputeAdjStartFromAdjNum(nSpheres,
+    ComputeAdjOffsetFromAdjNum(nSpheres,
                               sphere_data->adj_num,
                               sphere_data->adj_offset);
     
@@ -239,7 +239,7 @@ __host__ void ConstructGraphByProximity(
                                                                   nSpheres,
                                                                   radius);
     /// compute all adjacent spheres inside radius
-    ComputeAdjStartFromAdjNum(nSpheres,
+    ComputeAdjOffsetFromAdjNum(nSpheres,
                               sphere_data->adj_num,
                               sphere_data->adj_offset);
     /// compute adjacency list

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -55,7 +55,7 @@ static __global__ void ClusterSearchBFSKernel(unsigned int nSpheres,
     }
 }
 
-/// Identifies all clusters by breadth first search and outputs 
+/// Identifies all clusters by breadth first search and outputs
 /// Returns h_clusters: array of pointers to arrays of variable length
 /// h_clusters[0][0] -> number of pointers/cluster in h_clusters
 /// h_clusters[M][0] -> size of the Mth cluster

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -26,35 +26,6 @@
 namespace chrono {
 namespace gpu {
 
-/// ClusterSearchBFSKernel: GPU part of Breadth First Search (BFS) algorithm
-/// Visits all border spheres (d_borders) in parallel, finds neighbors
-/// Neighbors put into d_borders, visited on next call
-/// Call until no border spheres i.e. nothing true in d_borders
-static __global__ void ClusterSearchBFSKernel(unsigned int nSpheres,
-                                              unsigned int * adj_num,
-                                              unsigned int * adj_offset,
-                                              unsigned int * adj_list,
-                                              bool * d_borders,
-                                              bool * d_visited) {
-    // my sphere ID, we're using a 1D thread->sphere map
-    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    if (mySphereID < nSpheres) {
-        if (d_borders[mySphereID]) {
-            d_visited[mySphereID] = true;
-            d_borders[mySphereID] = false;
-
-            unsigned int start = adj_offset[mySphereID];
-            unsigned int end = adj_offset[mySphereID] + adj_num[mySphereID];
-            for (size_t i = start; i < end; i++) {
-                unsigned int neighborSphereID = adj_list[i];
-                if (!d_visited[neighborSphereID]) {
-                    d_borders[neighborSphereID] = true;
-                }
-            }
-        }
-    }
-}
-
 /// Identifies all clusters by breadth first search and outputs
 /// Returns h_clusters: array of pointers to arrays of variable length
 /// h_clusters[0][0] -> number of pointers/cluster in h_clusters
@@ -222,85 +193,6 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaDeviceSynchronize());
     return(h_clusters);
-}
-
-/// UNTESTED
-/// counts number of adjacent spheres by proximity.
-static __global__ void ComputeAdjNumByProximity(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres, float radius) {
-    // my sphere ID, we're using a 1D thread->sphere map
-    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    unsigned int otherSphereID;
-
-    unsigned int thisSD = blockIdx.x;
-    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
-    unsigned int otherSD;
-
-    int3 mySphere_pos_local, otherSphere_pos_local;
-    double3 mySphere_pos_global, otherSphere_pos_global, distance;
-
-    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID],
-                                   sphere_data->sphere_local_pos_Y[mySphereID],
-                                   sphere_data->sphere_local_pos_Z[mySphereID]);
-    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));
-
-    if (mySphereID < nSpheres) {
-    /// find all spheres inside the radius around mySphere
-        for (size_t i = 0; (i < nSpheres); i++) {
-            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i],
-            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD,
-                otherSphere_pos_local, gran_params));
-            distance = mySphere_pos_global - otherSphere_pos_global;
-            if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
-                sphere_data->adj_num[i]++;
-                sphere_data->adj_num[mySphereID]++;
-            }
-        }
-    }
-}
-
-/// UNTESTED
-/// computes adj_list from proximity using known adj_num and adj_offset
-static __global__ void ComputeAdjListByProximity(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres, float radius) {
-    // my sphere ID, we're using a 1D thread->sphere map
-    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    unsigned int otherSphereID;
-
-    // sphere_pos_local is relative to thisSD
-    unsigned int thisSD = blockIdx.x;
-    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
-    unsigned int otherSD;
-
-    unsigned int vertex_start = sphere_data->adj_offset[mySphereID];
-    unsigned int adjacency_num = 0;
-
-    int3 mySphere_pos_local, otherSphere_pos_local;
-    double3 mySphere_pos_global, otherSphere_pos_global, distance;
-
-    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID],
-            sphere_data->sphere_local_pos_Y[mySphereID],
-            sphere_data->sphere_local_pos_Z[mySphereID]);
-    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));
-
-    if (mySphereID < nSpheres) {
-        for (size_t i = 0; (i < nSpheres); i++) {
-            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i],
-            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD,
-                otherSphere_pos_local, gran_params));
-            distance = mySphere_pos_global - otherSphere_pos_global;
-            if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
-                sphere_data->adj_list[vertex_start + adjacency_num] = i;
-            }
-        }
-    }
-    assert(adjacency_num == sphere_data->adj_num[mySphereID]);
 }
 
 }  // namespace gpu

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -120,6 +120,7 @@ static __host__ unsigned int ** ClusterSearchBFS(unsigned int nSpheres,
             gpuErrchk(cudaDeviceSynchronize());
             h_cluster_num++;
 
+            // visit all spheres connected to sphere i in parallel
             do {
                 ClusterSearchBFSKernel<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
                 adj_num, adj_start, adj_list,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -9,9 +9,11 @@
 // http://projectchrono.org/license-chrono.txt.
 //
 //
-// Contains collision helper functions from ChNarrowphaseR
+// Contains functions that separated soil particles into clusters
+// Reference: Andrade, Guilherme, et al. "G-dbscan: A gpu accelerated algorithm 
+// for density-based clustering." Procedia Computer Science 18 (2013): 369-378.
 // =============================================================================
-// Authors: Conlain Kelly, Nic Olsen, Dan Negrut
+// Authors: Gabriel Taillon
 // =============================================================================
 
 #pragma once

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -1,0 +1,260 @@
+// =============================================================================
+// PROJECT CHRONO - http://projectchrono.org
+//
+// Copyright (c) 2019 projectchrono.org
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file at the top level of the distribution and at
+// http://projectchrono.org/license-chrono.txt.
+//
+//
+// Contains collision helper functions from ChNarrowphaseR
+// =============================================================================
+// Authors: Conlain Kelly, Nic Olsen, Dan Negrut
+// =============================================================================
+
+#pragma once
+
+#include "chrono_thirdparty/cub/cub.cuh"
+
+#include <cuda.h>
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+#include <ios>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <cstdint>
+#include <algorithm>
+
+#include "chrono_gpu/ChGpuDefines.h"
+#include "chrono_gpu/physics/ChSystemGpu_impl.h"
+#include "chrono_gpu/cuda/ChCudaMathUtils.cuh"
+#include "chrono_gpu/cuda/ChGpuHelpers.cuh"
+
+using chrono::gpu::CHGPU_TIME_INTEGRATOR;
+using chrono::gpu::CHGPU_FRICTION_MODE;
+using chrono::gpu::CHGPU_ROLLING_MODE;
+using chrono::gpu::SPHERE_GROUP;
+using chrono::gpu::CLUSTER_GRAPH_METHOD;
+using chrono::gpu::CLUSTER_SEARCH_METHOD;
+
+
+/// @addtogroup gpu_cuda
+/// @{
+
+
+/// counts number of adjacent spheres by proximity.
+static __global__ void construct_adj_num_start_by_proximity(
+                        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                        ChSystemGpu_impl::GranParamsPtr gran_params,
+                        unsigned int nSpheres, float radius) {
+
+    // my sphere ID, we're using a 1D thread->sphere map
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+    unsigned int otherSphereID;
+
+    unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
+    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
+    unsigned int otherSD;
+
+    int3 mySphere_pos_local, otherSphere_pos_local;
+    double3 mySphere_pos_global, otherSphere_pos_local, distance;
+
+    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
+            sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
+    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
+
+    if (mySphereID < nSpheres) {
+    /// find all spheres inside the radius around mySphere
+        for (size_t i = 0; (i < nSpheres); i++) {
+            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
+            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
+            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
+        distance = mySphere_pos_global - otherSphere_pos_global;
+            if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
+                adj_num[i]++;
+                adj_num[mySphereID]++;
+        adj_start[i+1]++;
+        /// perform an inclusive sum. start index of subsequent vertices depend on all previous indices.
+        void * d_temp_storage = NULL;
+        size_t temp_storage_bytesize = 0;
+        cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+        gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytesize));
+        cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+        }
+    }
+    }
+}
+
+/// computes adj_list from proximity using known adj_num and adj_start
+static __global__ void construct_adj_list_by_proximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                           ChSystemGpu_impl::GranParamsPtr gran_params,
+                                           unsigned int nSpheres, float radius,
+                                           unsigned int* adj_num,
+                                           unsigned int* adj_start,
+                                           unsigned int* adj_list) {
+    // my sphere ID, we're using a 1D thread->sphere map
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+    unsigned int otherSphereID;
+
+    unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
+    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
+    unsigned int otherSD;
+
+    unsigned int vertex_start = adj_start[mySphereID];
+    unsigned int adjacency_num = 0;
+
+    int3 mySphere_pos_local, otherSphere_pos_local;
+    double3 mySphere_pos_global, otherSphere_pos_local;
+
+    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
+            sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
+    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
+
+    if (mySphereID < nSpheres) {
+        for (size_t i = 0; (i < nSpheres); i++) {
+            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
+            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
+            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
+            distance = mySphere_pos_global - otherSphere_pos_global;
+            if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
+                adj_list[vertex_start + adjacency_num] = i;
+        }
+        }                  
+    }
+    assert(adjacency_num == vertex_adjacency_num[mySphereID]);
+}
+
+static __global__ void initial_sphere_group_gdbscan(unsigned int nSpheres,
+                                           unsigned int* adj_num,
+                                           SPHERE_GROUP* sphere_group,
+                                           unsigned int minPts) {
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+    sphere_group[mySphereID] = adj_num[mySphereID] > minPts ? SPHERE_GROUP::CORE : SPHERE_GROUP::NOISE;
+}
+
+/// computes cluster by breadth first search
+/// return pointer to clusters: array of pointers to arrays of variable length
+/// cluster[0][0] -> number of pointers
+/// cluster[M][0] -> size of the Mth cluster
+/// cluster[M][N] -> Nth point in Mth cluster
+static __host__ unsigned int * cluster_search_BFS(unsigned int nSpheres,
+                        unsigned int* adj_num,
+                        unsigned int* adj_start,
+                        unsigned int* adj_list,
+                        SPHERE_GROUP* sphere_group) {
+    unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
+
+    unsigned int ** clusters;
+    // how to use vectors in CUDA?
+
+    unsigned int cluster_index = 1; /// cluster 0 is reserved for ground.
+
+    bool * borders; // [mySphereID] -> is vertex a border?
+    bool * visited; // [mySphereID] -> was vertex visited?
+    bool * visited_host; // [mySphereID] -> was vertex visited?
+    gpuErrchk(cudaMalloc(&borders, sizeof(*borders) * nSpheres));
+    gpuErrchk(cudaMalloc(&visited, sizeof(*visited) * nSpheres));
+    visited_host = (bool *)calloc(sizeof(*visited_host), nSpheres);
+    
+
+    for (size_t i = 0; i < nSpheres; i++) {
+        if (!visited_host[i]) {
+            gpuErrchk(cudaMemset(&borders, false, sizeof(*borders) * nSpheres));
+            gpuErrchk(cudaMemset(&visited, false, sizeof(*visited) * nSpheres));
+            visited_host[i] = true;
+            borders[i] = true;
+            clustering_search_BFS_kernel<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSPheres,
+                radius, adj_num, adj_start, adj_list,
+                borders, visited);
+
+            gpuErrchk(cudaMemcpy(visited_host, visited, sizeof(*visited) * nSpheres, cudaMemcpyDeeviceToHost));
+
+            // cluster[0] is its size, so it length nSpheres + 1
+            for (size_t i = 0; i < nSpheres; i++) {
+                if (visited_host[i]) {
+                   cluster[cluster[0]++] = i;
+                }
+            }
+            cluster_index++;
+        }
+    gpuErrchk(cudaFree(borders));
+    gpuErrchk(cudaFree(visited));
+}
+
+/// computes cluster by breadth first search 
+static __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
+                        unsigned int * adj_num
+                        unsigned int * adj_start
+                        unsigned int * adj_list,
+                        bool * borders, bool * visited) {
+
+    // my sphere ID, we're using a 1D thread->sphere map
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+    unsigned int neighborSphereID;
+
+    if (visited[mySphereID]) {
+        visited[mySphereID] = true;
+    borders[mySphereID] = false;
+    unsigned int start = adj_start[mySphereID];
+    unsigned int end = adj_start[mySphereID] + vertex_adjacency_num[mySphereID];
+    for (size_t i = start; i < end; i++) {
+        unsigned int neighborSphereID = adj_list[i];
+        border[neighborSphereID] = !visited[neighborSphereID];
+        }
+    }
+}
+
+
+/// G-DBSCAN; density-based clustering algorithm. Identifies core, border and noise points in clusters.
+/// min_pts: minimal number of points for a cluster
+/// radius: proximity radius, points inside can form a cluster
+static __host__ void clustering_gdbscan(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                           ChSystemGpu_impl::GranParamsPtr gran_params,
+                                           unsigned int nSpheres, size_t min_pts, float radius) {
+    unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
+
+    initial_sphere_group_gdbscan<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSPheres,
+                radius, adj_num, adj_start, adj_list,
+                borders, visited);
+    /// 3 steps:
+    ///     1- compute all adjacent spheres inside radius
+    construct_adj_num_start_by_proximity<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data, gran_params, nSPheres,
+            radius, adj_num, adj_start);
+
+    ///     2- compute adjacency list
+    construct_adj_list_by_proximity<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data, gran_params, nSPheres,
+            radius, adj_num, adj_start, adj_list);
+
+
+    ///     3- build clusters by breadth-first search (BFS)
+    unsigned int cluster = malloc((nSpheres + 1) * sizeof(*cluster)); 
+    bool * points_visited = calloc(snSpheres, sizeof(*point_visited)); 
+    unsigned int * cluster;
+    for (size_t i = 0; i < nSpheres; i++) {
+        if (!point_visited[i]) {
+            memset(cluster, 0, sizeof(*cluster) * (nSPheres + 1));
+            cluster = clustering_search_BFS(sphere_data, gran_params, nSPheres,
+                radius, adj_num, adj_start, adj_list, cluster);
+            if (cluster[0] < min_pts) {
+                sphere_data->sphere_group[cluster[j]] = SPHERE_GROUP::NOISE;
+            } else {
+                for (size_t j = 0; j < cluster[0]; j++) {
+                    points_visited[cluster[j]] = true;
+                    if (adj_num[cluster[j]] >= min_pts) {
+                        sphere_data->sphere_group[cluster[j]] = SPHERE_GROUP::CORE;
+                    } else {
+                        sphere_data->sphere_group[cluster[j]] = SPHERE_GROUP::BORDER;
+                    }
+                }
+            }
+            points_visited[i] = true;
+        }
+    }
+    free(cluster);
+}
+
+/// @} gpu_cuda

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -230,6 +230,8 @@ static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,
 //     return(h_clusters);
 // }
 
+
+
 // /// computes h_cluster by breadth first search
 // static __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
 //                         unsigned int * adj_num,
@@ -296,10 +298,23 @@ static __global__ void update_cluster_group(ChSystemGpu_impl::GranSphereDataPtr 
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     for (size_t i = 0; i < sphere_num_in_cluster; i++) { 
         if (cluster[i] == mySphereID) {
-            sphere_data->sphere_cluster = cluster_id;
+            sphere_data->sphere_cluster[mySphereID] = cluster_id;
         }
     }
 }
+
+__host__ void gdbscan_search_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                           ChSystemGpu_impl::GranParamsPtr gran_params,
+                                           unsigned int nSpheres, size_t min_pts);
+
+
+// __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
+//                         unsigned int * adj_num,
+//                         unsigned int * adj_start,
+//                         unsigned int * adj_list,
+//                         bool * d_borders, 
+//                         bool * d_visited);
+
 
 // /// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
 // /// min_pts: minimal number of points for a cluster

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -50,9 +50,9 @@ using chrono::gpu::CLUSTER_SEARCH_METHOD;
 
 /// All spheres with > minPts contacts are core, other points maybe be border points.
 static __global__ void GdbscanInitSphereGroup(unsigned int nSpheres,
-                                           unsigned int* adj_num,
-                                           SPHERE_GROUP* sphere_group,
-                                           unsigned int minPts) {
+                                              unsigned int* adj_num,
+                                              SPHERE_GROUP* sphere_group,
+                                              unsigned int minPts) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
@@ -76,8 +76,8 @@ static __global__ void SetVolumeSphereGroup(ChSystemGpu_impl::GranSphereDataPtr 
 /// Any particle with sphere_group == NOISE are not part of any cluster
 /// sphere_cluster is tagged INVALID
 static __global__ void GdbscanFinalClusterFromGroup(unsigned int nSpheres,
-                                           unsigned int* sphere_cluster,
-                                           SPHERE_GROUP* sphere_group) {
+                                                    unsigned int* sphere_cluster,
+                                                    SPHERE_GROUP* sphere_group) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
@@ -91,9 +91,9 @@ static __global__ void GdbscanFinalClusterFromGroup(unsigned int nSpheres,
 // if any of volume is true, this is the volume cluster UNLESS
 // it is the biggest cluster -> becomes the ground cluster.
 static __global__ void FindVolumeCluster(unsigned int nSpheres,
-                                           bool * visited,
-                                           bool * in_volume,
-                                           SPHERE_GROUP* sphere_group) {
+                                         bool * visited,
+                                         bool * in_volume,
+                                         SPHERE_GROUP* sphere_group) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
@@ -107,8 +107,8 @@ static __global__ void FindVolumeCluster(unsigned int nSpheres,
 /// needs fully known adj_num
 /// call BEFORE ComputeAdjList___
 static __host__ void ComputeAdjStartFromAdjNum(unsigned int nSpheres, 
-                                                unsigned int * adj_num,
-                                                unsigned int * adj_start) {
+                                               unsigned int * adj_num,
+                                               unsigned int * adj_start) {
     memcpy(adj_start, adj_num, sizeof(*adj_start) * nSpheres);
     /// all start indices after mySphereID depend on it -> exclusive sum
     void * d_temp_storage = NULL;
@@ -126,9 +126,10 @@ static __host__ void ComputeAdjStartFromAdjNum(unsigned int nSpheres,
 /// compute adj_num from chrono contact_active_map
 /// adj_start needs fully known adj_num 
 /// adl_list needs fully known adj_list 
-static __global__ void ComputeAdjNumByContact(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres) {
+static __global__ void ComputeAdjNumByContact(
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+        ChSystemGpu_impl::GranParamsPtr gran_params,
+        unsigned int nSpheres) {
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -151,9 +152,10 @@ static __global__ void ComputeAdjNumByContact(ChSystemGpu_impl::GranSphereDataPt
 /// compute adj_list from chrono contact_active_map.
 /// called AFTER ComputeAdjNumByContact and ComputeAdjStartFromAdjNum
 /// adj_list needs fully known ajd_start
-static __global__ void ComputeAdjListByContact(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres) {
+static __global__ void ComputeAdjListByContact(
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+        ChSystemGpu_impl::GranParamsPtr gran_params,
+        unsigned int nSpheres) {
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -172,12 +174,14 @@ static __global__ void ComputeAdjListByContact(ChSystemGpu_impl::GranSphereDataP
     }
 }
 
-__host__ void GdbscanConstructGraph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres, size_t min_pts, float radius);
+__host__ void GdbscanConstructGraph(
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+        ChSystemGpu_impl::GranParamsPtr gran_params,
+        unsigned int nSpheres, size_t min_pts, float radius);
 
-__host__ void GdbscanSearchGraph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres, size_t min_pts);
+__host__ void GdbscanSearchGraph(
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+        ChSystemGpu_impl::GranParamsPtr gran_params,
+        unsigned int nSpheres, size_t min_pts);
 
 /// @} gpu_cuda

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -278,6 +278,7 @@ static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,
 static __host__ void gdbscan_construct_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
                                            unsigned int nSpheres, size_t min_pts, float radius) {
+    printf("gdbscan_construct_graph");
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
     // /// 2 steps:
@@ -290,16 +291,21 @@ static __host__ void gdbscan_construct_graph(ChSystemGpu_impl::GranSphereDataPtr
     //         radius, adj_num, adj_start, adj_list);
 }
 
+/// if cluster is NULL, just update all spheres to cluster.
 static __global__ void update_cluster_group(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
                                            unsigned int sphere_num_in_cluster,
                                            unsigned int cluster_id,
                                            unsigned int * cluster) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    for (size_t i = 0; i < sphere_num_in_cluster; i++) { 
-        if (cluster[i] == mySphereID) {
-            sphere_data->sphere_cluster[mySphereID] = cluster_id;
+    if (cluster!= NULL)  {
+        for (size_t i = 0; i < sphere_num_in_cluster; i++) { 
+            if (cluster[i] == mySphereID) {
+                sphere_data->sphere_cluster[mySphereID] = cluster_id;
+            }
         }
+    } else {
+        sphere_data->sphere_cluster[mySphereID] = cluster_id;
     }
 }
 

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -114,7 +114,7 @@ static __global__ void FindVolumeCluster(unsigned int nSpheres,
 /// Compute adj_offset from adj_num with ExclusiveSum
 /// needs fully known adj_num
 /// call BEFORE ComputeAdjList___
-static __host__ void ComputeAdjStartFromAdjNum(unsigned int nSpheres,
+static __host__ void ComputeAdjOffsetFromAdjNum(unsigned int nSpheres,
                                                unsigned int * adj_num,
                                                unsigned int * adj_offset) {
     memcpy(adj_offset, adj_num, sizeof(*adj_offset) * nSpheres);
@@ -162,7 +162,7 @@ static __global__ void ComputeAdjNumByContact(
 }
 
 /// Compute adj_list from chrono contact_active_map.
-/// call AFTER ComputeAdjNumByContact and ComputeAdjStartFromAdjNum
+/// call AFTER ComputeAdjNumByContact and ComputeAdjOffsetFromAdjNum
 /// adj_list needs fully known ajd_start, which needs fully known adj_num
 static __global__ void ComputeAdjListByContact(
         ChSystemGpu_impl::GranSphereDataPtr sphere_data,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -73,19 +73,19 @@ static __global__ void construct_adj_num_start_by_proximity(
             otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
             sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
             otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
-        distance = mySphere_pos_global - otherSphere_pos_global;
-            if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
-                adj_num[i]++;
-                adj_num[mySphereID]++;
-        adj_start[i+1]++;
-        /// perform an inclusive sum. start index of subsequent vertices depend on all previous indices.
-        void * d_temp_storage = NULL;
-        size_t temp_storage_bytesize = 0;
-        cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
-        gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytesize));
-        cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+            distance = mySphere_pos_global - otherSphere_pos_global;
+                if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
+                    adj_num[i]++;
+                    adj_num[mySphereID]++;
+                }
+            adj_start[i+1]++;
+            /// perform an inclusive sum. start index of subsequent vertices depend on all previous indices.
+            void * d_temp_storage = NULL;
+            size_t temp_storage_bytesize = 0;
+            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+            gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytesize));
+            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
         }
-    }
     }
 }
 
@@ -123,13 +123,13 @@ static __global__ void construct_adj_list_by_proximity(ChSystemGpu_impl::GranSph
             distance = mySphere_pos_global - otherSphere_pos_global;
             if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
                 adj_list[vertex_start + adjacency_num] = i;
-        }
+            }
         }                  
     }
     assert(adjacency_num == vertex_adjacency_num[mySphereID]);
 }
 
-static __global__ void initial_sphere_group_gdbscan(unsigned int nSpheres,
+static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,
                                            unsigned int* adj_num,
                                            SPHERE_GROUP* sphere_group,
                                            unsigned int minPts) {
@@ -137,11 +137,9 @@ static __global__ void initial_sphere_group_gdbscan(unsigned int nSpheres,
     sphere_group[mySphereID] = adj_num[mySphereID] > minPts ? SPHERE_GROUP::CORE : SPHERE_GROUP::NOISE;
 }
 
-/// computes cluster by breadth first search
-/// return pointer to clusters: array of pointers to arrays of variable length
-/// cluster[0][0] -> number of pointers
-/// cluster[M][0] -> size of the Mth cluster
-/// cluster[M][N] -> Nth point in Mth cluster
+/// computes h_cluster by breadth first search
+/// return pointer to h_clusters: array of pointers to arrays of variable length
+
 static __host__ unsigned int * cluster_search_BFS(unsigned int nSpheres,
                         unsigned int* adj_num,
                         unsigned int* adj_start,
@@ -149,128 +147,167 @@ static __host__ unsigned int * cluster_search_BFS(unsigned int nSpheres,
                         SPHERE_GROUP* sphere_group) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
-    unsigned int ** clusters;
-    // how to use vectors in CUDA?
+    /// CLUSTERS REPRESENTATION IN MEMORY
+    /// ALTERNATIVE 1:
+    /// clusters, array of points to arrays of variable lengths, with lengths at [0]
+    unsigned int * h_cluster;
+    unsigned int h_cluster_num = 1;
+    unsigned int ** h_clusters;
+    h_clusters = (unsigned int *)malloc(sizeof(*h_clusters) * (nSpheres+1)); // at worst, there will be nSpheres h_clusters
+    h_clusters[0] = (unsigned int *)malloc(sizeof(**h_clusters)); // number of h_clusters at h_clusters[0][0]
+    /// h_clusters[0][0] -> number of pointers/h_clusters
+    /// h_clusters[M][0] -> size of the Mth h_cluster
+    /// h_clusters[M][N] -> Nth point in Mth h_cluster
 
-    unsigned int cluster_index = 1; /// cluster 0 is reserved for ground.
+    /// CLUSTERS REPRESENTATION IN MEMORY
+    /// ALTERNATIVE 2:
+    // /// cluster_list/cluster_num/sphere_in_cluster_num similar to adj_num, adj_list (annoying to ouput)
+    // unsigned int * h_cluster_list;
+    // unsigned int h_cluster_num; /// number of spheres in each cluster
+    // unsigned int * h_sphere_num_in_cluster; /// number of spheres in each cluster
+    // unsigned int * h_cluster_start; /// index where cluster list starts in h_cluster_list
+    // h_cluster_list = (unsigned int *)malloc(sizeof(*h_cluster_list) * nSpheres); // there is only nSpheres in ALL clusters
+    // h_cluster_start = (unsigned int *)malloc(sizeof(*h_cluster_start) * nSpheres); // at worst, there will be nSpheres h_clusters
+    // h_sphere_num_in_cluster = (unsigned int *)malloc(sizeof(*h_sphere_num_in_cluster) * nSpheres); // at worst, there will be nSpheres h_clusters
 
-    bool * borders; // [mySphereID] -> is vertex a border?
-    bool * visited; // [mySphereID] -> was vertex visited?
-    bool * visited_host; // [mySphereID] -> was vertex visited?
-    gpuErrchk(cudaMalloc(&borders, sizeof(*borders) * nSpheres));
-    gpuErrchk(cudaMalloc(&visited, sizeof(*visited) * nSpheres));
-    visited_host = (bool *)calloc(sizeof(*visited_host), nSpheres);
-    
+    bool * d_borders; // [mySphereID] -> is vertex a border?
+    bool * d_visited; // [mySphereID] -> was vertex d_visited during BFS_kernel?
+    bool * h_visited; // [mySphereID] -> host of d_visited
+    bool * h_searched; // [mySphereID] -> was vertex searched before?
+    unsigned int * d_border_num; // number of remaining border vertices to search in BFS_kernel
+    unsigned int * h_border_num; // number of remaining border vertices to search in BFS_kernl
+    gpuErrchk(cudaMalloc((void**)&d_borders, sizeof(*d_borders) * nSpheres));
+    gpuErrchk(cudaMalloc((void**)&d_visited, sizeof(*d_visited) * nSpheres));
+    gpuErrchk(cudaMalloc((void**)&d_border_num, sizeof(*d_border_num));
+    h_visited = (bool *)calloc(sizeof(*h_visited), nSpheres);
+    h_searched = (bool *)calloc(sizeof(*h_searched), nSpheres);
+    SPHERE_GROUP h_current_group;
 
     for (size_t i = 0; i < nSpheres; i++) {
-        if (!visited_host[i]) {
-            gpuErrchk(cudaMemset(&borders, false, sizeof(*borders) * nSpheres));
-            gpuErrchk(cudaMemset(&visited, false, sizeof(*visited) * nSpheres));
-            visited_host[i] = true;
-            borders[i] = true;
-            clustering_search_BFS_kernel<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSPheres,
+        gpuErrchk(cudaMemcpy(&h_current_group, &(sphere_data->sphere_group + i), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
+        /// find the next h_cluster, at the first sphere not yet searched.
+        if ((!h_searched[i]) && (h_current_group == SPHERE_GROUP::CORE)) {
+            gpuErrchk(cudaMemset(&d_borders, false, sizeof(*d_borders) * nSpheres));
+            gpuErrchk(cudaMemset(&d_visited, false, sizeof(*d_visited) * nSpheres));
+            gpuErrchk(cudaMemset(&(d_border_num), 1, sizeof(*d_border_num)));
+            gpuErrchk(cudaMemset(&(d_borders + i), true, sizeof(*d_borders)));
+            h_searched[i] = true;
+
+            do {
+            h_clustering_search_BFS_kernel<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
                 radius, adj_num, adj_start, adj_list,
-                borders, visited);
-
-            gpuErrchk(cudaMemcpy(visited_host, visited, sizeof(*visited) * nSpheres, cudaMemcpyDeeviceToHost));
-
-            // cluster[0] is its size, so it length nSpheres + 1
-            for (size_t i = 0; i < nSpheres; i++) {
-                if (visited_host[i]) {
-                   cluster[cluster[0]++] = i;
+                d_borders, d_visited, d_border_num);
+                gpuErrchk(cudaMemcpy(&h_border_num, &d_border_num, sizeof(*d_border_num)), cudaMemcpyDeviceToHost);
+            } while (h_border_num > 0);
+            
+            gpuErrchk(cudaMemcpy(&h_visited, &d_visited, sizeof(*d_visited)* nSpheres, cudaMemcpyDeviceToHost);
+            h_cluster = (unsigned int *)malloc(sizeof(*h_cluster) * (nSpheres + 1));
+            // h_cluster[0] is its size, so it length nSpheres + 1
+            for (size_t j = 0; i < nSpheres; j++) {
+                if (h_visited[j]) {
+                    h_searched[j] = true;
+                    h_cluster[h_cluster[0]++] = j;
+                    gpuErrchk(cudaMemcpy(&h_current_group, &(sphere_data->sphere_group + j), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
+                    if (h_current_group != SPHERE_GROUP::CORE) {
+                       gpuErrchk(cudaMemset(&(sphere_data->sphere_group + j), SPHERE_GROUP::BORDER, sizeof(*sphere_data->sphere_group)));
+                    }
                 }
             }
-            cluster_index++;
+            h_cluster = (unsigned int *)realloc(h_cluster, sizeof(*h_cluster) * (h_cluster[0]));
+            h_clusters[h_cluster_num] = h_cluster;
+            h_clusters[0][0] = ++h_cluster_num; // h_clusters size is number of clusters + 1 cause it includes its length 
         }
-    gpuErrchk(cudaFree(borders));
-    gpuErrchk(cudaFree(visited));
+    }
+    h_clusters = (unsigned int *)realloc(h_clusters, sizeof(*h_clusters) * (h_clusters[0][0]));
+
+    free(h_visited);
+    free(h_searched);
+    free(h_border_num);
+    free(h_current_group);
+    gpuErrchk(cudaFree(d_borders));
+    gpuErrchk(cudaFree(d_border_num));
+    gpuErrchk(cudaFree(d_visited));
+    return(h_clusters);
 }
 
-/// computes cluster by breadth first search 
+/// computes h_cluster by breadth first search
 static __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
                         unsigned int * adj_num
                         unsigned int * adj_start
                         unsigned int * adj_list,
-                        bool * borders, bool * visited) {
+                        bool * d_borders, 
+                        bool * d_visited,
+                        unsigned int * d_border_num) {
 
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     unsigned int neighborSphereID;
 
-    if (visited[mySphereID]) {
-        visited[mySphereID] = true;
-    borders[mySphereID] = false;
-    unsigned int start = adj_start[mySphereID];
-    unsigned int end = adj_start[mySphereID] + vertex_adjacency_num[mySphereID];
-    for (size_t i = start; i < end; i++) {
-        unsigned int neighborSphereID = adj_list[i];
-        border[neighborSphereID] = !visited[neighborSphereID];
+    if (d_visited[mySphereID]) {
+        d_visited[mySphereID] = true;
+        d_borders[mySphereID] = false;
+        atomicAdd(d_border_num, -1);
+        unsigned int start = adj_start[mySphereID];
+        unsigned int end = adj_start[mySphereID] + vertex_adjacency_num[mySphereID];
+        for (size_t i = start; i < end; i++) {
+            unsigned int neighborSphereID = adj_list[i];
+            if (!d_visited[neighborSphereID]) {
+                border[neighborSphereID] = true;
+                atomicAdd(d_border_num, 1);
+            }
         }
     }
 }
 
 /// UNTESTED
-/// G-DBSCAN; density-based clustering algorithm. Identifies core, border and noise points in clusters.
+/// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
 /// SEARCH STEP
-/// min_pts: minimal number of points for a cluster
-/// radius: proximity radius, points inside can form a cluster
+/// min_pts: minimal number of points for a h_cluster
+/// radius: proximity radius, points inside can form a h_cluster
 static __host__ void gdbscan_construct_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
                                            unsigned int nSpheres, size_t min_pts, float radius) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
-    initial_sphere_group_gdbscan<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSPheres,
-                radius, adj_num, adj_start, adj_list,
-                borders, visited);
     /// 2 steps:
     ///     1- compute all adjacent spheres inside radius
-    construct_adj_num_start_by_proximity<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data, gran_params, nSPheres,
+    construct_adj_num_start_by_proximity<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data, gran_params, nSpheres,
             radius, adj_num, adj_start);
 
     ///     2- compute adjacency list
-    construct_adj_list_by_proximity<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data, gran_params, nSPheres,
+    construct_adj_list_by_proximity<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data, gran_params, nSpheres,
             radius, adj_num, adj_start, adj_list);
 }
 
 
-/// G-DBSCAN; density-based clustering algorithm. Identifies core, border and noise points in clusters.
-/// min_pts: minimal number of points for a cluster
-/// radius: proximity radius, points inside can form a cluster
-/// return clusters array of pointers to arrays of different sizes 
+/// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
+/// min_pts: minimal number of points for a h_cluster
+/// radius: proximity radius, points inside can form a h_cluster
+/// return h_clusters array of pointers to arrays of different sizes
 static __host__ unsigned int* gdbscan_search_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres, size_t min_pts, float radius) {
+                                           unsigned int nSpheres, size_t min_pts) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
-    initial_sphere_group_gdbscan<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSPheres,
-                radius, adj_num, adj_start, adj_list,
-                borders, visited);
+    init_sphere_group_gdbscan<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
+                sphere_data->adj_num, sphere_data->sphere_group, minPts);
 
-    ///     3- build clusters by breadth-first search (BFS)
-    // unsigned int cluster = malloc((nSpheres + 1) * sizeof(*cluster)); 
-    // bool * points_visited = calloc(snSpheres, sizeof(*point_visited)); 
-    // unsigned int * cluster;
-    // for (size_t i = 0; i < nSpheres; i++) {
-    //     if (!point_visited[i]) {
-    //         memset(cluster, 0, sizeof(*cluster) * (nSPheres + 1));
-    //         cluster = clustering_search_BFS(sphere_data, gran_params, nSPheres,
-    //             radius, adj_num, adj_start, adj_list, cluster);
-    //         if (cluster[0] < min_pts) {
-    //             sphere_data->sphere_group[cluster[j]] = SPHERE_GROUP::NOISE;
-    //         } else {
-    //             for (size_t j = 0; j < cluster[0]; j++) {
-    //                 points_visited[cluster[j]] = true;
-    //                 if (adj_num[cluster[j]] >= min_pts) {
-    //                     sphere_data->sphere_group[cluster[j]] = SPHERE_GROUP::CORE;
-    //                 } else {
-    //                     sphere_data->sphere_group[cluster[j]] = SPHERE_GROUP::BORDER;
-    //                 }
-    //             }
-    //         }
-    //         points_visited[i] = true;
-    //     }
-    // }
-    // free(cluster);
+    unsigned int h_clusters * cluster_search_BFS(nSpheres,
+                                        sphere_data->adj_num,
+                                        sphere_data->adj_start,
+                                        sphere_data->adj_list,
+                                        sphere_data->sphere_group) {
+
+    unsigned int cluster_num = h_clusters[0][0];
+    unsigned int * sphere_num_in_cluster = (unsigned int *);
+    for (size_t i = 0; i < h_clusters[0][0]) { // expect low number of clusters, 1 most of the time, maybe 2-3 otherwise.
+        sphere_num_in_cluster = h_clusters[i][0];
+    }    
+
+    for (size_t i = 0; i < h_clusters[0][0]) {
+        free(h_clusters[i]);
+    }
+    free(h_clusters);
 }
 
 /// @} gpu_cuda

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -117,14 +117,14 @@ static __host__ void ComputeAdjStartFromAdjNum(unsigned int nSpheres,
                                                 unsigned int * adj_num,
                                                 unsigned int * adj_start) {
     memcpy(adj_start, adj_num, sizeof(*adj_start) * nSpheres);
-    /// all start indices after mySphereID depend on it -> inclusive sum
+    /// all start indices after mySphereID depend on it -> exclusive sum
     void * d_temp_storage = NULL;
     size_t bytesize = 0;
-    /// with d_temp_storage = NULL, InclusiveSum computes necessary bytesize
+    /// with d_temp_storage = NULL, ExclusiveSum computes necessary bytesize
     cub::DeviceScan::ExclusiveSum(d_temp_storage, bytesize,
     adj_start, adj_start, nSpheres);
     gpuErrchk(cudaMalloc(&d_temp_storage, bytesize));
-    /// Actually perform IncluseSum
+    /// Actually perform ExcluseSum
     cub::DeviceScan::ExclusiveSum(d_temp_storage, bytesize,
     adj_start, adj_start, nSpheres);
     gpuErrchk(cudaFree(d_temp_storage));

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -45,91 +45,8 @@ using chrono::gpu::CLUSTER_SEARCH_METHOD;
 /// @addtogroup gpu_cuda
 /// @{
 
-// /// UNTESTED
-// /// counts number of adjacent spheres by proximity.
-// static __global__ void construct_adj_num_start_by_proximity(
-//                         ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-//                         ChSystemGpu_impl::GranParamsPtr gran_params,
-//                         unsigned int nSpheres, float radius) {
-
-//     // my sphere ID, we're using a 1D thread->sphere map
-//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-//     unsigned int otherSphereID;
-
-//     unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
-//     unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
-//     unsigned int otherSD;
-
-//     int3 mySphere_pos_local, otherSphere_pos_local;
-//     double3 mySphere_pos_global, otherSphere_pos_local, distance;
-
-//     mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
-//             sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
-//     mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
-
-//     if (mySphereID < nSpheres) {
-//     /// find all spheres inside the radius around mySphere
-//         for (size_t i = 0; (i < nSpheres); i++) {
-//             otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
-//             sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-//             otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
-//             distance = mySphere_pos_global - otherSphere_pos_global;
-//                 if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
-//                     adj_num[i]++;
-//                     adj_num[mySphereID]++;
-//                 }
-//             adj_start[i+1]++;
-//             /// perform an inclusive sum. start index of subsequent vertices depend on all previous indices.
-//             void * d_temp_storage = NULL;
-//             size_t temp_storage_bytesize = 0;
-//             cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
-//             gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytesize));
-//             cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
-//         }
-//     }
-// }
-
-// /// UNTESTED
-// /// computes adj_list from proximity using known adj_num and adj_start
-// static __global__ void construct_adj_list_by_proximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-//                                            ChSystemGpu_impl::GranParamsPtr gran_params,
-//                                            unsigned int nSpheres, float radius,
-//                                            unsigned int* adj_num,
-//                                            unsigned int* adj_start,
-//                                            unsigned int* adj_list) {
-//     // my sphere ID, we're using a 1D thread->sphere map
-//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-//     unsigned int otherSphereID;
-
-//     unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
-//     unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
-//     unsigned int otherSD;
-
-//     unsigned int vertex_start = adj_start[mySphereID];
-//     unsigned int adjacency_num = 0;
-
-//     int3 mySphere_pos_local, otherSphere_pos_local;
-//     double3 mySphere_pos_global, otherSphere_pos_global;
-
-//     mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
-//             sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
-//     mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
-
-//     if (mySphereID < nSpheres) {
-//         for (size_t i = 0; (i < nSpheres); i++) {
-//             otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
-//             sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-//             otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
-//             distance = mySphere_pos_global - otherSphere_pos_global;
-//             if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
-//                 adj_list[vertex_start + adjacency_num] = i;
-//             }
-//         }                  
-//     }
-//     assert(adjacency_num == vertex_adjacency_num[mySphereID]);
-// }
-
 /// All spheres with > minPts contacts are core, other points maybe be border points.
+// InitSphereGroup
 static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,
                                            unsigned int* adj_num,
                                            SPHERE_GROUP* sphere_group,
@@ -138,143 +55,11 @@ static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,
     sphere_group[mySphereID] = adj_num[mySphereID] > minPts ? SPHERE_GROUP::CORE : SPHERE_GROUP::NOISE;
 }
 
-// /// computes h_cluster by breadth first search
-// /// return pointer to h_clusters: array of pointers to arrays of variable length
-// static __host__ unsigned int * cluster_search_BFS(unsigned int nSpheres,
-//                         unsigned int* adj_num,
-//                         unsigned int* adj_start,
-//                         unsigned int* adj_list,
-//                         SPHERE_GROUP* sphere_group) {
-//     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
-
-//     /// CLUSTERS REPRESENTATION IN MEMORY
-//     /// ALTERNATIVE 1:
-//     /// clusters, array of points to arrays of variable lengths, with lengths at [0]
-//     unsigned int * h_cluster;
-//     unsigned int h_cluster_num = 1;
-//     unsigned int ** h_clusters;
-//     h_clusters = (unsigned int *)malloc(sizeof(*h_clusters) * (nSpheres+1)); // at worst, there will be nSpheres h_clusters
-//     h_clusters[0] = (unsigned int *)malloc(sizeof(**h_clusters)); // number of h_clusters at h_clusters[0][0]
-//     /// h_clusters[0][0] -> number of pointers/h_clusters
-//     /// h_clusters[M][0] -> size of the Mth h_cluster
-//     /// h_clusters[M][N] -> Nth point in Mth h_cluster
-
-//     /// CLUSTERS REPRESENTATION IN MEMORY
-//     /// ALTERNATIVE 2:
-//     // /// cluster_list/cluster_num/sphere_in_cluster_num similar to adj_num, adj_list (annoying to ouput)
-//     // unsigned int * h_cluster_list;
-//     // unsigned int h_cluster_num; /// number of spheres in each cluster
-//     // unsigned int * h_sphere_num_in_cluster; /// number of spheres in each cluster
-//     // unsigned int * h_cluster_start; /// index where cluster list starts in h_cluster_list
-//     // h_cluster_list = (unsigned int *)malloc(sizeof(*h_cluster_list) * nSpheres); // there is only nSpheres in ALL clusters
-//     // h_cluster_start = (unsigned int *)malloc(sizeof(*h_cluster_start) * nSpheres); // at worst, there will be nSpheres h_clusters
-//     // h_sphere_num_in_cluster = (unsigned int *)malloc(sizeof(*h_sphere_num_in_cluster) * nSpheres); // at worst, there will be nSpheres h_clusters
-
-//     bool * d_borders; // [mySphereID] -> is vertex a border?
-//     bool * d_visited; // [mySphereID] -> was vertex d_visited during BFS_kernel?
-//     bool * h_visited; // [mySphereID] -> host of d_visited
-//     bool * h_searched; // [mySphereID] -> was vertex searched before?
-//     unsigned int * d_border_num; // number of remaining border vertices to search in BFS_kernel
-//     unsigned int * h_border_num; // number of remaining border vertices to search in BFS_kernl
-//     gpuErrchk(cudaMalloc((void**)&d_borders, sizeof(*d_borders) * nSpheres));
-//     gpuErrchk(cudaMalloc((void**)&d_visited, sizeof(*d_visited) * nSpheres));
-//     gpuErrchk(cudaMalloc((void**)&d_border_num, sizeof(*d_border_num));
-//     h_visited = (bool *)calloc(sizeof(*h_visited), nSpheres);
-//     h_searched = (bool *)calloc(sizeof(*h_searched), nSpheres);
-//     SPHERE_GROUP h_current_group;
-
-//     for (size_t i = 0; i < nSpheres; i++) {
-//         gpuErrchk(cudaMemcpy(h_current_group, (sphere_data->sphere_group + i), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
-//         /// find the next h_cluster, at the first sphere not yet searched.
-//         if ((!h_searched[i]) && (h_current_group == SPHERE_GROUP::CORE)) {
-//             gpuErrchk(cudaMemset(&d_borders, false, sizeof(*d_borders) * nSpheres));
-//             gpuErrchk(cudaMemset(&d_visited, false, sizeof(*d_visited) * nSpheres));
-//             gpuErrchk(cudaMemset(&(d_border_num), 1, sizeof(*d_border_num)));
-//             gpuErrchk(cudaMemset(&(d_borders + i), true, sizeof(*d_borders)));
-//             h_searched[i] = true;
-
-//             do {
-//             h_clustering_search_BFS_kernel<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
-//                 radius, adj_num, adj_start, adj_list,
-//                 d_borders, d_visited, d_border_num);
-//                 gpuErrchk(cudaMemcpy(h_border_num, d_border_num, sizeof(*d_border_num)), cudaMemcpyDeviceToHost);
-//             } while (h_border_num > 0);
-            
-//             gpuErrchk(cudaMemcpy(h_visited, d_visited, sizeof(*d_visited)* nSpheres, cudaMemcpyDeviceToHost);
-//             h_cluster = (unsigned int *)malloc(sizeof(*h_cluster) * (nSpheres + 1));
-//             // h_cluster[0] is its size, so it length nSpheres + 1
-//             for (size_t j = 0; i < nSpheres; j++) {
-//                 if (h_visited[j]) {
-//                     h_searched[j] = true;
-//                     h_cluster[h_cluster[0]++] = j;
-//                     gpuErrchk(cudaMemcpy(&h_current_group, &(sphere_data->sphere_group + j), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
-//                     if (h_current_group != SPHERE_GROUP::CORE) {
-//                        gpuErrchk(cudaMemset(&(sphere_data->sphere_group + j), SPHERE_GROUP::BORDER, sizeof(*sphere_data->sphere_group)));
-//                     }
-//                 }
-//             }
-//             h_cluster = (unsigned int *)realloc(h_cluster, sizeof(*h_cluster) * (h_cluster[0]));
-//             h_clusters[h_cluster_num] = h_cluster;
-//             h_clusters[0][0] = ++h_cluster_num; // h_clusters size is number of clusters + 1 cause it includes its length 
-//         }
-//     }
-//     h_clusters = (unsigned int *)realloc(h_clusters, sizeof(*h_clusters) * (h_clusters[0][0]));
-
-//     free(h_visited);
-//     free(h_searched);
-//     free(h_border_num);
-//     free(h_current_group);
-//     gpuErrchk(cudaFree(d_borders));
-//     gpuErrchk(cudaFree(d_border_num));
-//     gpuErrchk(cudaFree(d_visited));
-//     return(h_clusters);
-// }
-
-
-
-// /// computes h_cluster by breadth first search
-// static __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
-//                         unsigned int * adj_num,
-//                         unsigned int * adj_start,
-//                         unsigned int * adj_list,
-//                         bool * d_borders, 
-//                         bool * d_visited,
-//                         unsigned int * d_border_num) {
-
-//     // my sphere ID, we're using a 1D thread->sphere map
-//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-//     if (d_visited[mySphereID]) {
-//         d_visited[mySphereID] = true;
-//         d_borders[mySphereID] = false;
-
-
-//         unsigned int start = adj_start[mySphereID];
-//         unsigned int end = adj_start[mySphereID] + vertex_adjacency_num[mySphereID];
-//         for (size_t i = start; i < end; i++) {
-//             unsigned int neighborSphereID = adj_list[i];
-//             if (!d_visited[neighborSphereID]) {
-//                 d_borders[neighborSphereID] = true;
-//             }
-//         }
-
-//         // Determine temporary device storage requirements
-//         void *d_temp_storage = NULL;
-//         size_t temp_storage_bytes = 0;
-//         cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, d_borders, d_border_num, nSpheres);
-//         // Allocate temporary storage
-//         gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytes));
-//         // Run sum-reduction
-//         cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, d_borders, d_border_num, nSpheres);
-//         gpuErrchk(cudaFree(d_temp_storage));
-
-//     }
-// }
-
-/// UNTESTED
 /// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
 /// SEARCH STEP
 /// min_pts: minimal number of points for a h_cluster
 /// radius: proximity radius, points inside can form a h_cluster
+/// GdbscanConstructGraph
 static __host__ void gdbscan_construct_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
                                            unsigned int nSpheres, size_t min_pts, float radius) {
@@ -292,6 +77,7 @@ static __host__ void gdbscan_construct_graph(ChSystemGpu_impl::GranSphereDataPtr
 }
 
 // compute adj_start from adj_num. assumes memory was allocated
+// ComputeAdjStartFromAdjNum
 static __host__ void cluster_adj_num2start(unsigned int nSpheres, unsigned int * adj_num, unsigned int * adj_start) {
     memcpy(adj_start, adj_num, sizeof(*adj_start) * nSpheres);
     /// all start indices after mySphereID depend on it -> inclusive sum
@@ -308,7 +94,7 @@ static __host__ void cluster_adj_num2start(unsigned int nSpheres, unsigned int *
 }
 
 
-/// if cluster is NULL, just update all spheres to cluster.
+/// InitSphereCluster
 static __global__ void init_sphere_cluster(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
                                            unsigned int cluster_id) {
@@ -316,65 +102,74 @@ static __global__ void init_sphere_cluster(ChSystemGpu_impl::GranSphereDataPtr s
     sphere_data->sphere_cluster[mySphereID] = cluster_id;
 }
 
+/// InitAdj
+static __global__ void init_adj(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                           ChSystemGpu_impl::GranParamsPtr gran_params,
+                                           unsigned int nSpheres) {
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+    if (mySphereID < nSpheres) {
+        sphere_data->adj_num[mySphereID] = 0;
+        sphere_data->adj_start[mySphereID] = 0;
+        for (unsigned int i = mySphereID; i < mySphereID + MAX_SPHERES_TOUCHED_BY_SPHERE ; i++) {
+            sphere_data->adj_list[i] = 0;
+        }
+    }
+}
+
+/// compute adj_num from chrono contact_active_map
+/// need to be separate from ComputeAdjListByContact to compute adj_start
+// FIND BETTER NAMES
+// ComputeAdjNumByContact
+static __global__ void cluster_contact_adj_num(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                           ChSystemGpu_impl::GranParamsPtr gran_params,
+                                           unsigned int nSpheres) {
+    // my sphere ID, we're using a 1D thread->sphere map
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+
+    // don't overrun the array
+    if (mySphereID < nSpheres) {
+        size_t body_A_offset = MAX_SPHERES_TOUCHED_BY_SPHERE * mySphereID;
+
+        // count the number of contacts.
+        unsigned char numActiveContacts = 0;
+        for (unsigned char body_B_offset = 0; body_B_offset < MAX_SPHERES_TOUCHED_BY_SPHERE; body_B_offset++) {
+            bool active_contact = sphere_data->contact_active_map[body_A_offset + body_B_offset];
+            if (active_contact) {
+                numActiveContacts++;
+            }
+        }
+        sphere_data->adj_num[mySphereID] = numActiveContacts;
+    }
+}
+
+/// compute adj_num from chrono contact_active_map
+// FIND BETTER NAMES
+// ComputeAdjNumByContact
+static __global__ void cluster_contact_adj_list(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                           ChSystemGpu_impl::GranParamsPtr gran_params,
+                                           unsigned int nSpheres) {
+    // my sphere ID, we're using a 1D thread->sphere map
+    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+
+    // don't overrun the array
+    if (mySphereID < nSpheres) {
+        size_t body_A_offset = MAX_SPHERES_TOUCHED_BY_SPHERE * mySphereID;
+
+        unsigned char numActiveContacts = 0;
+        for (unsigned char body_B_offset = 0; body_B_offset < MAX_SPHERES_TOUCHED_BY_SPHERE; body_B_offset++) {
+            bool active_contact = sphere_data->contact_active_map[body_A_offset + body_B_offset];
+            if (active_contact) {
+                sphere_data->adj_list[sphere_data->adj_start[mySphereID] + numActiveContacts] = sphere_data->contact_partners_map[body_A_offset + body_B_offset];;
+                numActiveContacts++;
+            }
+        }
+    }
+}
+
+/// GdbscanSearchGraph
 __host__ void gdbscan_search_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
                                            unsigned int nSpheres, size_t min_pts);
 
-
-// __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
-//                         unsigned int * adj_num,
-//                         unsigned int * adj_start,
-//                         unsigned int * adj_list,
-//                         bool * d_borders, 
-//                         bool * d_visited);
-
-
-// /// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
-// /// min_pts: minimal number of points for a cluster
-// static __host__ void gdbscan_search_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-//                                            ChSystemGpu_impl::GranParamsPtr gran_params,
-//                                            unsigned int nSpheres, size_t min_pts) {
-//     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
-
-//     init_sphere_group_gdbscan<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
-//                 sphere_data->adj_num, sphere_data->sphere_group, minPts);
-
-//     unsigned int h_clusters * cluster_search_BFS(nSpheres, sphere_data->adj_num,
-//                                         sphere_data->adj_start,
-//                                         sphere_data->adj_list,
-//                                         sphere_data->sphere_group);
-
-//     unsigned int * d_cluster;
-//     unsigned int cluster_num = h_clusters[0][0];
-//     unsigned int sphere_num_in_cluster;
-//     unsigned int biggest_cluster_size = 1;
-//     unsigned int biggest_cluster_id = 1;
-
-//     // find biggest cluster id
-//     for (size_t i = 0; i <  cluster_num, i++) {// expect low number of clusters, 1 most of the time, maybe 2-3 otherwise.
-//         sphere_num_in_cluster = h_clusters[i][0];
-//         if (sphere_num_in_cluster > biggest_cluster_size) {
-//             biggest_cluster_size = sphere_num_in_cluster;
-//             biggest_cluster_id = i;
-//         }
-//     }    
-
-//     // tag each sphere to a cluster_group
-//     for (size_t i = 1; i < h_cluster_num; i++) {// expect low number of clusters, 1 most of the time, maybe 2-3 otherwise.
-//         unsigned int cluster_id = (biggest_cluster == i) ? CLUSTER_GROUP::GROUND : i;
-//         gpuErrchk(cudaMalloc(&d_cluster, h_clusters[i][0]));
-//         gpuErrchk(cudaMemcpy(d_cluster, h_clusters[i] + 1, sizeof(*d_cluster) * h_clusters[i][0]));
-//         sphere_num_in_cluster = h_clusters[i][0];
-//         update_cluster_group<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data,
-//                                             gran_params, sphere_num_in_cluster,
-//                                             cluster_id, d_cluster);
-//         gpuErrchk(cudaFree(d_cluster));
-//     }
-
-//     for (size_t i = 0; i < h_clusters[0][0]) {
-//         free(h_clusters[i]);
-//     }
-//     free(h_clusters);
-// }
 
 /// @} gpu_cuda

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -56,9 +56,9 @@ using chrono::gpu::CLUSTER_SEARCH_METHOD;
 /// spheres with > minPts contacts are CORE, others are NOISE
 /// Only NOISE spheres may be changed to BORDER later
 static __global__ void GdbscanInitSphereType(unsigned int nSpheres,
-                                              unsigned int* adj_num,
-                                              SPHERE_TYPE* sphere_type,
-                                              unsigned int minPts) {
+                                             unsigned int* adj_num,
+                                             SPHERE_TYPE* sphere_type,
+                                             unsigned int minPts) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
@@ -70,7 +70,7 @@ static __global__ void GdbscanInitSphereType(unsigned int nSpheres,
 // Tag spheres found inside mesh to type VOLUME
 // must run AFTER interactionGranMat_TriangleSoup
 static __global__ void SetVolumeSphereType(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                            unsigned int nSpheres) {
+                                           unsigned int nSpheres) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
@@ -84,8 +84,8 @@ static __global__ void SetVolumeSphereType(ChSystemGpu_impl::GranSphereDataPtr s
 /// -> sphere_cluster = INVALID
 /// Should be run at the end of search step
 static __global__ void GdbscanFinalClusterFromType(unsigned int nSpheres,
-                                                    unsigned int* sphere_cluster,
-                                                    SPHERE_TYPE* sphere_type) {
+                                                   unsigned int* sphere_cluster,
+                                                   SPHERE_TYPE* sphere_type) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
@@ -137,10 +137,9 @@ static __host__ void ComputeAdjOffsetFromAdjNum(unsigned int nSpheres,
 /// Compute adj_num from chrono contact_active_map
 /// adj_offset needs fully known adj_num
 /// adl_list needs fully known adj_offset
-static __global__ void ComputeAdjNumByContact(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres) {
+static __global__ void ComputeAdjNumByContact(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                              ChSystemGpu_impl::GranParamsPtr gran_params,
+                                              unsigned int nSpheres) {
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -164,10 +163,9 @@ static __global__ void ComputeAdjNumByContact(
 /// Compute adj_list from chrono contact_active_map.
 /// call AFTER ComputeAdjNumByContact and ComputeAdjOffsetFromAdjNum
 /// adj_list needs fully known ajd_start, which needs fully known adj_num
-static __global__ void ComputeAdjListByContact(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres) {
+static __global__ void ComputeAdjListByContact(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                               ChSystemGpu_impl::GranParamsPtr gran_params,
+                                               unsigned int nSpheres) {
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -219,10 +217,10 @@ static __global__ void ClusterSearchBFSKernel(unsigned int nSpheres,
 
 /// UNTESTED
 /// counts number of adjacent spheres by proximity.
-static __global__ void ComputeAdjNumByProximity(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres, float radius) {
+static __global__ void ComputeAdjNumByProximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                                ChSystemGpu_impl::GranParamsPtr gran_params,
+                                                unsigned int nSpheres,
+                                                float radius) {
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     unsigned int otherSphereID;
@@ -257,10 +255,10 @@ static __global__ void ComputeAdjNumByProximity(
 
 /// UNTESTED
 /// computes adj_list from proximity using known adj_num and adj_offset
-static __global__ void ComputeAdjListByProximity(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres, float radius) {
+static __global__ void ComputeAdjListByProximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                                 ChSystemGpu_impl::GranParamsPtr gran_params,
+                                                 unsigned int nSpheres,
+                                                 float radius) {
     // my sphere ID, we're using a 1D thread->sphere map
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     unsigned int otherSphereID;
@@ -296,19 +294,19 @@ static __global__ void ComputeAdjListByProximity(
     assert(adjacency_num == sphere_data->adj_num[mySphereID]);
 }
 
-__host__ void ConstructGraphByContact(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres);
+__host__ void ConstructGraphByContact(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                      ChSystemGpu_impl::GranParamsPtr gran_params,
+                                      unsigned int nSpheres);
 
-__host__ void ConstructGraphByProximity(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres, size_t min_pts, float radius);
+__host__ void ConstructGraphByProximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                        ChSystemGpu_impl::GranParamsPtr gran_params,
+                                        unsigned int nSpheres,
+                                        size_t min_pts,
+                                        float radius);
 
-__host__ void GdbscanSearchGraph(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int nSpheres, size_t min_pts);
+__host__ void GdbscanSearchGraph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                 ChSystemGpu_impl::GranParamsPtr gran_params,
+                                 unsigned int nSpheres,
+                                 size_t min_pts);
 
 /// @} gpu_cuda

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -99,7 +99,7 @@ static __global__ void GdbscanFinalClusterFromGroup(unsigned int nSpheres,
 // find if any particle is in the volume cluster.
 // if any of volume is true, this is the volume cluster UNLESS
 // it is the biggest cluster -> becomes the ground cluster.
-static __global__ void FindBucketCluster(unsigned int nSpheres,
+static __global__ void FindVolumeCluster(unsigned int nSpheres,
                                            bool * visited,
                                            bool * in_volume,
                                            SPHERE_GROUP* sphere_group) {

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -77,6 +77,7 @@ static __global__ void SetVolumeSphereGroup(ChSystemGpu_impl::GranSphereDataPtr 
     if (mySphereID < nSpheres) {
         if (sphere_data->sphere_inside_mesh[mySphereID]) {
            sphere_data->sphere_group[mySphereID] = SPHERE_GROUP::VOLUME;
+       }
     }
 }
 
@@ -92,14 +93,18 @@ static __global__ void GdbscanFinalClusterFromGroup(unsigned int nSpheres,
     }
 }
 
-static __global__ void GdbscanFinalClusterFromGroup(unsigned int nSpheres,
-                                           unsigned int* sphere_cluster,
+// find if any particle is in the bucket cluster.
+// if any of bucket is true, this is the bucket cluster UNLESS
+// it is the biggest cluster -> becomes the ground cluster.
+static __global__ void FindBucketCluster(unsigned int nSpheres,
+                                           bool * visited,
+                                           bool * in_bucket,
                                            SPHERE_GROUP* sphere_group) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
-        if (sphere_group[mySphereID] == SPHERE_GROUP::NOISE) {
-            sphere_cluster[mySphereID] = static_cast<unsigned int>(chrono::gpu::CLUSTER_INDEX::INVALID);
+        if ((sphere_group[mySphereID] == SPHERE_GROUP::VOLUME) && (visited[mySphereID])) {
+            in_bucket[mySphereID] = true;
         }
     }
 }

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -241,9 +241,12 @@ static __global__ void ComputeAdjNumByProximity(ChSystemGpu_impl::GranSphereData
     /// find all spheres inside the radius around mySphere
         for (size_t i = 0; (i < nSpheres); i++) {
             otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i],
-            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD,
-                otherSphere_pos_local, gran_params));
+                                              sphere_data->sphere_local_pos_Y[i],
+                                              sphere_data->sphere_local_pos_Z[i]);
+            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(
+                thisSD,
+                otherSphere_pos_local,
+                gran_params));
             distance = mySphere_pos_global - otherSphere_pos_global;
             if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
                 sphere_data->adj_num[i]++;
@@ -275,16 +278,22 @@ static __global__ void ComputeAdjListByProximity(ChSystemGpu_impl::GranSphereDat
     double3 mySphere_pos_global, otherSphere_pos_global, distance;
 
     mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID],
-            sphere_data->sphere_local_pos_Y[mySphereID],
-            sphere_data->sphere_local_pos_Z[mySphereID]);
-    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));
+                                   sphere_data->sphere_local_pos_Y[mySphereID],
+                                   sphere_data->sphere_local_pos_Z[mySphereID]);
+    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(
+        thisSD,
+        mySphere_pos_local,
+        gran_params));
 
     if (mySphereID < nSpheres) {
         for (size_t i = 0; (i < nSpheres); i++) {
             otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i],
-            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD,
-                otherSphere_pos_local, gran_params));
+                                              sphere_data->sphere_local_pos_Y[i],
+                                              sphere_data->sphere_local_pos_Z[i]);
+            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(
+                thisSD,
+                otherSphere_pos_local,
+                gran_params));
             distance = mySphere_pos_global - otherSphere_pos_global;
             if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
                 sphere_data->adj_list[vertex_start + adjacency_num] = i;

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -96,18 +96,18 @@ static __global__ void GdbscanFinalClusterFromGroup(unsigned int nSpheres,
     }
 }
 
-// find if any particle is in the bucket cluster.
-// if any of bucket is true, this is the bucket cluster UNLESS
+// find if any particle is in the volume cluster.
+// if any of volume is true, this is the volume cluster UNLESS
 // it is the biggest cluster -> becomes the ground cluster.
 static __global__ void FindBucketCluster(unsigned int nSpheres,
                                            bool * visited,
-                                           bool * in_bucket,
+                                           bool * in_volume,
                                            SPHERE_GROUP* sphere_group) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
         if ((sphere_group[mySphereID] == SPHERE_GROUP::VOLUME) && (visited[mySphereID])) {
-            in_bucket[mySphereID] = true;
+            in_volume[mySphereID] = true;
         }
     }
 }

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -61,16 +61,6 @@ static __global__ void GdbscanInitSphereGroup(unsigned int nSpheres,
     }
 }
 
-static __global__ void GdbscanInitSphereCluster(unsigned int nSpheres,
-                                            unsigned int* sphere_cluster,
-                                           unsigned int cluster_id) {
-    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    // don't overrun the array
-    if (mySphereID < nSpheres) {
-        sphere_cluster[mySphereID] = cluster_id;
-    }
-}
-
 // set spheres found inside mesh to group VOLUME
 // must de run AFTER interactionGranMat_TriangleSoup()
 static __global__ void SetVolumeSphereGroup(ChSystemGpu_impl::GranSphereDataPtr sphere_data,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -230,32 +230,43 @@ static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,
 //     return(h_clusters);
 // }
 
-/// computes h_cluster by breadth first search
-static __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
-                        unsigned int * adj_num,
-                        unsigned int * adj_start,
-                        unsigned int * adj_list,
-                        bool * d_borders, 
-                        bool * d_visited,
-                        unsigned int * d_border_num) {
+// /// computes h_cluster by breadth first search
+// static __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
+//                         unsigned int * adj_num,
+//                         unsigned int * adj_start,
+//                         unsigned int * adj_list,
+//                         bool * d_borders, 
+//                         bool * d_visited,
+//                         unsigned int * d_border_num) {
 
-    // my sphere ID, we're using a 1D thread->sphere map
-    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    if (d_visited[mySphereID]) {
-        d_visited[mySphereID] = true;
-        d_borders[mySphereID] = false;
-        atomicAdd(d_border_num, -1);
-        unsigned int start = adj_start[mySphereID];
-        unsigned int end = adj_start[mySphereID] + vertex_adjacency_num[mySphereID];
-        for (size_t i = start; i < end; i++) {
-            unsigned int neighborSphereID = adj_list[i];
-            if (!d_visited[neighborSphereID]) {
-                d_borders[neighborSphereID] = true;
-                atomicAdd(d_border_num, 1);
-            }
-        }
-    }
-}
+//     // my sphere ID, we're using a 1D thread->sphere map
+//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+//     if (d_visited[mySphereID]) {
+//         d_visited[mySphereID] = true;
+//         d_borders[mySphereID] = false;
+
+
+//         unsigned int start = adj_start[mySphereID];
+//         unsigned int end = adj_start[mySphereID] + vertex_adjacency_num[mySphereID];
+//         for (size_t i = start; i < end; i++) {
+//             unsigned int neighborSphereID = adj_list[i];
+//             if (!d_visited[neighborSphereID]) {
+//                 d_borders[neighborSphereID] = true;
+//             }
+//         }
+
+//         // Determine temporary device storage requirements
+//         void *d_temp_storage = NULL;
+//         size_t temp_storage_bytes = 0;
+//         cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, d_borders, d_border_num, nSpheres);
+//         // Allocate temporary storage
+//         gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytes));
+//         // Run sum-reduction
+//         cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, d_borders, d_border_num, nSpheres);
+//         gpuErrchk(cudaFree(d_temp_storage));
+
+//     }
+// }
 
 /// UNTESTED
 /// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -292,21 +292,11 @@ static __host__ void gdbscan_construct_graph(ChSystemGpu_impl::GranSphereDataPtr
 }
 
 /// if cluster is NULL, just update all spheres to cluster.
-static __global__ void update_cluster_group(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+static __global__ void init_sphere_cluster(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int sphere_num_in_cluster,
-                                           unsigned int cluster_id,
-                                           unsigned int * cluster) {
+                                           unsigned int cluster_id) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    if (cluster!= NULL)  {
-        for (size_t i = 0; i < sphere_num_in_cluster; i++) { 
-            if (cluster[i] == mySphereID) {
-                sphere_data->sphere_cluster[mySphereID] = cluster_id;
-            }
-        }
-    } else {
-        sphere_data->sphere_cluster[mySphereID] = cluster_id;
-    }
+    sphere_data->sphere_cluster[mySphereID] = cluster_id;
 }
 
 __host__ void gdbscan_search_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -121,11 +121,14 @@ static __host__ void ComputeAdjStartFromAdjNum(unsigned int nSpheres,
     cub::DeviceScan::ExclusiveSum(d_temp_storage, bytesize,
     adj_start, adj_start, nSpheres);
     gpuErrchk(cudaFree(d_temp_storage));
+
+    gpuErrchk(cudaPeekAtLastError());
+    gpuErrchk(cudaDeviceSynchronize());
 }
 
 /// compute adj_num from chrono contact_active_map
-/// adj_start needs fully known adj_num 
-/// adl_list needs fully known adj_list 
+/// adj_start needs fully known adj_num
+/// adl_list needs fully known adj_list
 static __global__ void ComputeAdjNumByContact(
         ChSystemGpu_impl::GranSphereDataPtr sphere_data,
         ChSystemGpu_impl::GranParamsPtr gran_params,
@@ -174,7 +177,12 @@ static __global__ void ComputeAdjListByContact(
     }
 }
 
-__host__ void GdbscanConstructGraph(
+__host__ void ConstructGraphByContact(
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+        ChSystemGpu_impl::GranParamsPtr gran_params,
+        unsigned int nSpheres);
+
+__host__ void ConstructGraphByProximity(
         ChSystemGpu_impl::GranSphereDataPtr sphere_data,
         ChSystemGpu_impl::GranParamsPtr gran_params,
         unsigned int nSpheres, size_t min_pts, float radius);

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -45,89 +45,89 @@ using chrono::gpu::CLUSTER_SEARCH_METHOD;
 /// @addtogroup gpu_cuda
 /// @{
 
-/// UNTESTED
-/// counts number of adjacent spheres by proximity.
-static __global__ void construct_adj_num_start_by_proximity(
-                        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                        ChSystemGpu_impl::GranParamsPtr gran_params,
-                        unsigned int nSpheres, float radius) {
+// /// UNTESTED
+// /// counts number of adjacent spheres by proximity.
+// static __global__ void construct_adj_num_start_by_proximity(
+//                         ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+//                         ChSystemGpu_impl::GranParamsPtr gran_params,
+//                         unsigned int nSpheres, float radius) {
 
-    // my sphere ID, we're using a 1D thread->sphere map
-    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    unsigned int otherSphereID;
+//     // my sphere ID, we're using a 1D thread->sphere map
+//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+//     unsigned int otherSphereID;
 
-    unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
-    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
-    unsigned int otherSD;
+//     unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
+//     unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
+//     unsigned int otherSD;
 
-    int3 mySphere_pos_local, otherSphere_pos_local;
-    double3 mySphere_pos_global, otherSphere_pos_local, distance;
+//     int3 mySphere_pos_local, otherSphere_pos_local;
+//     double3 mySphere_pos_global, otherSphere_pos_local, distance;
 
-    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
-            sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
-    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
+//     mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
+//             sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
+//     mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
 
-    if (mySphereID < nSpheres) {
-    /// find all spheres inside the radius around mySphere
-        for (size_t i = 0; (i < nSpheres); i++) {
-            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
-            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
-            distance = mySphere_pos_global - otherSphere_pos_global;
-                if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
-                    adj_num[i]++;
-                    adj_num[mySphereID]++;
-                }
-            adj_start[i+1]++;
-            /// perform an inclusive sum. start index of subsequent vertices depend on all previous indices.
-            void * d_temp_storage = NULL;
-            size_t temp_storage_bytesize = 0;
-            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
-            gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytesize));
-            cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
-        }
-    }
-}
+//     if (mySphereID < nSpheres) {
+//     /// find all spheres inside the radius around mySphere
+//         for (size_t i = 0; (i < nSpheres); i++) {
+//             otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
+//             sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
+//             otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
+//             distance = mySphere_pos_global - otherSphere_pos_global;
+//                 if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
+//                     adj_num[i]++;
+//                     adj_num[mySphereID]++;
+//                 }
+//             adj_start[i+1]++;
+//             /// perform an inclusive sum. start index of subsequent vertices depend on all previous indices.
+//             void * d_temp_storage = NULL;
+//             size_t temp_storage_bytesize = 0;
+//             cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+//             gpuErrchk(cudaMalloc(&d_temp_storage, temp_storage_bytesize));
+//             cub::DeviceScan::InclusiveSum(d_temp_storage, temp_storage_bytesize, adj_start + i, adj_start + i, nSpheres - i);
+//         }
+//     }
+// }
 
-/// UNTESTED
-/// computes adj_list from proximity using known adj_num and adj_start
-static __global__ void construct_adj_list_by_proximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres, float radius,
-                                           unsigned int* adj_num,
-                                           unsigned int* adj_start,
-                                           unsigned int* adj_list) {
-    // my sphere ID, we're using a 1D thread->sphere map
-    unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    unsigned int otherSphereID;
+// /// UNTESTED
+// /// computes adj_list from proximity using known adj_num and adj_start
+// static __global__ void construct_adj_list_by_proximity(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+//                                            ChSystemGpu_impl::GranParamsPtr gran_params,
+//                                            unsigned int nSpheres, float radius,
+//                                            unsigned int* adj_num,
+//                                            unsigned int* adj_start,
+//                                            unsigned int* adj_list) {
+//     // my sphere ID, we're using a 1D thread->sphere map
+//     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+//     unsigned int otherSphereID;
 
-    unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
-    unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
-    unsigned int otherSD;
+//     unsigned int thisSD = blockIdx.x; // sphere_pos_local is relative to this SD
+//     unsigned int mySD = sphere_data->sphere_owner_SDs[mySphereID];
+//     unsigned int otherSD;
 
-    unsigned int vertex_start = adj_start[mySphereID];
-    unsigned int adjacency_num = 0;
+//     unsigned int vertex_start = adj_start[mySphereID];
+//     unsigned int adjacency_num = 0;
 
-    int3 mySphere_pos_local, otherSphere_pos_local;
-    double3 mySphere_pos_global, otherSphere_pos_local;
+//     int3 mySphere_pos_local, otherSphere_pos_local;
+//     double3 mySphere_pos_global, otherSphere_pos_global;
 
-    mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
-            sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
-    mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
+//     mySphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[mySphereID], 
+//             sphere_data->sphere_local_pos_Y[mySphereID], sphere_data->sphere_local_pos_Z[mySphereID]);
+//     mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));   
 
-    if (mySphereID < nSpheres) {
-        for (size_t i = 0; (i < nSpheres); i++) {
-            otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
-            sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
-            otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
-            distance = mySphere_pos_global - otherSphere_pos_global;
-            if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
-                adj_list[vertex_start + adjacency_num] = i;
-            }
-        }                  
-    }
-    assert(adjacency_num == vertex_adjacency_num[mySphereID]);
-}
+//     if (mySphereID < nSpheres) {
+//         for (size_t i = 0; (i < nSpheres); i++) {
+//             otherSphere_pos_local = make_int3(sphere_data->sphere_local_pos_X[i], 
+//             sphere_data->sphere_local_pos_Y[i], sphere_data->sphere_local_pos_Z[i]);
+//             otherSphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, otherSphere_pos_local, gran_params));   
+//             distance = mySphere_pos_global - otherSphere_pos_global;
+//             if ((i != mySphereID) && (Dot(distance, distance) < (radius*radius))) {
+//                 adj_list[vertex_start + adjacency_num] = i;
+//             }
+//         }                  
+//     }
+//     assert(adjacency_num == vertex_adjacency_num[mySphereID]);
+// }
 
 /// All spheres with > minPts contacts are core, other points maybe be border points.
 static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,
@@ -138,97 +138,97 @@ static __global__ void init_sphere_group_gdbscan(unsigned int nSpheres,
     sphere_group[mySphereID] = adj_num[mySphereID] > minPts ? SPHERE_GROUP::CORE : SPHERE_GROUP::NOISE;
 }
 
-/// computes h_cluster by breadth first search
-/// return pointer to h_clusters: array of pointers to arrays of variable length
-static __host__ unsigned int * cluster_search_BFS(unsigned int nSpheres,
-                        unsigned int* adj_num,
-                        unsigned int* adj_start,
-                        unsigned int* adj_list,
-                        SPHERE_GROUP* sphere_group) {
-    unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
+// /// computes h_cluster by breadth first search
+// /// return pointer to h_clusters: array of pointers to arrays of variable length
+// static __host__ unsigned int * cluster_search_BFS(unsigned int nSpheres,
+//                         unsigned int* adj_num,
+//                         unsigned int* adj_start,
+//                         unsigned int* adj_list,
+//                         SPHERE_GROUP* sphere_group) {
+//     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
-    /// CLUSTERS REPRESENTATION IN MEMORY
-    /// ALTERNATIVE 1:
-    /// clusters, array of points to arrays of variable lengths, with lengths at [0]
-    unsigned int * h_cluster;
-    unsigned int h_cluster_num = 1;
-    unsigned int ** h_clusters;
-    h_clusters = (unsigned int *)malloc(sizeof(*h_clusters) * (nSpheres+1)); // at worst, there will be nSpheres h_clusters
-    h_clusters[0] = (unsigned int *)malloc(sizeof(**h_clusters)); // number of h_clusters at h_clusters[0][0]
-    /// h_clusters[0][0] -> number of pointers/h_clusters
-    /// h_clusters[M][0] -> size of the Mth h_cluster
-    /// h_clusters[M][N] -> Nth point in Mth h_cluster
+//     /// CLUSTERS REPRESENTATION IN MEMORY
+//     /// ALTERNATIVE 1:
+//     /// clusters, array of points to arrays of variable lengths, with lengths at [0]
+//     unsigned int * h_cluster;
+//     unsigned int h_cluster_num = 1;
+//     unsigned int ** h_clusters;
+//     h_clusters = (unsigned int *)malloc(sizeof(*h_clusters) * (nSpheres+1)); // at worst, there will be nSpheres h_clusters
+//     h_clusters[0] = (unsigned int *)malloc(sizeof(**h_clusters)); // number of h_clusters at h_clusters[0][0]
+//     /// h_clusters[0][0] -> number of pointers/h_clusters
+//     /// h_clusters[M][0] -> size of the Mth h_cluster
+//     /// h_clusters[M][N] -> Nth point in Mth h_cluster
 
-    /// CLUSTERS REPRESENTATION IN MEMORY
-    /// ALTERNATIVE 2:
-    // /// cluster_list/cluster_num/sphere_in_cluster_num similar to adj_num, adj_list (annoying to ouput)
-    // unsigned int * h_cluster_list;
-    // unsigned int h_cluster_num; /// number of spheres in each cluster
-    // unsigned int * h_sphere_num_in_cluster; /// number of spheres in each cluster
-    // unsigned int * h_cluster_start; /// index where cluster list starts in h_cluster_list
-    // h_cluster_list = (unsigned int *)malloc(sizeof(*h_cluster_list) * nSpheres); // there is only nSpheres in ALL clusters
-    // h_cluster_start = (unsigned int *)malloc(sizeof(*h_cluster_start) * nSpheres); // at worst, there will be nSpheres h_clusters
-    // h_sphere_num_in_cluster = (unsigned int *)malloc(sizeof(*h_sphere_num_in_cluster) * nSpheres); // at worst, there will be nSpheres h_clusters
+//     /// CLUSTERS REPRESENTATION IN MEMORY
+//     /// ALTERNATIVE 2:
+//     // /// cluster_list/cluster_num/sphere_in_cluster_num similar to adj_num, adj_list (annoying to ouput)
+//     // unsigned int * h_cluster_list;
+//     // unsigned int h_cluster_num; /// number of spheres in each cluster
+//     // unsigned int * h_sphere_num_in_cluster; /// number of spheres in each cluster
+//     // unsigned int * h_cluster_start; /// index where cluster list starts in h_cluster_list
+//     // h_cluster_list = (unsigned int *)malloc(sizeof(*h_cluster_list) * nSpheres); // there is only nSpheres in ALL clusters
+//     // h_cluster_start = (unsigned int *)malloc(sizeof(*h_cluster_start) * nSpheres); // at worst, there will be nSpheres h_clusters
+//     // h_sphere_num_in_cluster = (unsigned int *)malloc(sizeof(*h_sphere_num_in_cluster) * nSpheres); // at worst, there will be nSpheres h_clusters
 
-    bool * d_borders; // [mySphereID] -> is vertex a border?
-    bool * d_visited; // [mySphereID] -> was vertex d_visited during BFS_kernel?
-    bool * h_visited; // [mySphereID] -> host of d_visited
-    bool * h_searched; // [mySphereID] -> was vertex searched before?
-    unsigned int * d_border_num; // number of remaining border vertices to search in BFS_kernel
-    unsigned int * h_border_num; // number of remaining border vertices to search in BFS_kernl
-    gpuErrchk(cudaMalloc((void**)&d_borders, sizeof(*d_borders) * nSpheres));
-    gpuErrchk(cudaMalloc((void**)&d_visited, sizeof(*d_visited) * nSpheres));
-    gpuErrchk(cudaMalloc((void**)&d_border_num, sizeof(*d_border_num));
-    h_visited = (bool *)calloc(sizeof(*h_visited), nSpheres);
-    h_searched = (bool *)calloc(sizeof(*h_searched), nSpheres);
-    SPHERE_GROUP h_current_group;
+//     bool * d_borders; // [mySphereID] -> is vertex a border?
+//     bool * d_visited; // [mySphereID] -> was vertex d_visited during BFS_kernel?
+//     bool * h_visited; // [mySphereID] -> host of d_visited
+//     bool * h_searched; // [mySphereID] -> was vertex searched before?
+//     unsigned int * d_border_num; // number of remaining border vertices to search in BFS_kernel
+//     unsigned int * h_border_num; // number of remaining border vertices to search in BFS_kernl
+//     gpuErrchk(cudaMalloc((void**)&d_borders, sizeof(*d_borders) * nSpheres));
+//     gpuErrchk(cudaMalloc((void**)&d_visited, sizeof(*d_visited) * nSpheres));
+//     gpuErrchk(cudaMalloc((void**)&d_border_num, sizeof(*d_border_num));
+//     h_visited = (bool *)calloc(sizeof(*h_visited), nSpheres);
+//     h_searched = (bool *)calloc(sizeof(*h_searched), nSpheres);
+//     SPHERE_GROUP h_current_group;
 
-    for (size_t i = 0; i < nSpheres; i++) {
-        gpuErrchk(cudaMemcpy(h_current_group, (sphere_data->sphere_group + i), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
-        /// find the next h_cluster, at the first sphere not yet searched.
-        if ((!h_searched[i]) && (h_current_group == SPHERE_GROUP::CORE)) {
-            gpuErrchk(cudaMemset(&d_borders, false, sizeof(*d_borders) * nSpheres));
-            gpuErrchk(cudaMemset(&d_visited, false, sizeof(*d_visited) * nSpheres));
-            gpuErrchk(cudaMemset(&(d_border_num), 1, sizeof(*d_border_num)));
-            gpuErrchk(cudaMemset(&(d_borders + i), true, sizeof(*d_borders)));
-            h_searched[i] = true;
+//     for (size_t i = 0; i < nSpheres; i++) {
+//         gpuErrchk(cudaMemcpy(h_current_group, (sphere_data->sphere_group + i), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
+//         /// find the next h_cluster, at the first sphere not yet searched.
+//         if ((!h_searched[i]) && (h_current_group == SPHERE_GROUP::CORE)) {
+//             gpuErrchk(cudaMemset(&d_borders, false, sizeof(*d_borders) * nSpheres));
+//             gpuErrchk(cudaMemset(&d_visited, false, sizeof(*d_visited) * nSpheres));
+//             gpuErrchk(cudaMemset(&(d_border_num), 1, sizeof(*d_border_num)));
+//             gpuErrchk(cudaMemset(&(d_borders + i), true, sizeof(*d_borders)));
+//             h_searched[i] = true;
 
-            do {
-            h_clustering_search_BFS_kernel<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
-                radius, adj_num, adj_start, adj_list,
-                d_borders, d_visited, d_border_num);
-                gpuErrchk(cudaMemcpy(h_border_num, d_border_num, sizeof(*d_border_num)), cudaMemcpyDeviceToHost);
-            } while (h_border_num > 0);
+//             do {
+//             h_clustering_search_BFS_kernel<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
+//                 radius, adj_num, adj_start, adj_list,
+//                 d_borders, d_visited, d_border_num);
+//                 gpuErrchk(cudaMemcpy(h_border_num, d_border_num, sizeof(*d_border_num)), cudaMemcpyDeviceToHost);
+//             } while (h_border_num > 0);
             
-            gpuErrchk(cudaMemcpy(h_visited, d_visited, sizeof(*d_visited)* nSpheres, cudaMemcpyDeviceToHost);
-            h_cluster = (unsigned int *)malloc(sizeof(*h_cluster) * (nSpheres + 1));
-            // h_cluster[0] is its size, so it length nSpheres + 1
-            for (size_t j = 0; i < nSpheres; j++) {
-                if (h_visited[j]) {
-                    h_searched[j] = true;
-                    h_cluster[h_cluster[0]++] = j;
-                    gpuErrchk(cudaMemcpy(&h_current_group, &(sphere_data->sphere_group + j), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
-                    if (h_current_group != SPHERE_GROUP::CORE) {
-                       gpuErrchk(cudaMemset(&(sphere_data->sphere_group + j), SPHERE_GROUP::BORDER, sizeof(*sphere_data->sphere_group)));
-                    }
-                }
-            }
-            h_cluster = (unsigned int *)realloc(h_cluster, sizeof(*h_cluster) * (h_cluster[0]));
-            h_clusters[h_cluster_num] = h_cluster;
-            h_clusters[0][0] = ++h_cluster_num; // h_clusters size is number of clusters + 1 cause it includes its length 
-        }
-    }
-    h_clusters = (unsigned int *)realloc(h_clusters, sizeof(*h_clusters) * (h_clusters[0][0]));
+//             gpuErrchk(cudaMemcpy(h_visited, d_visited, sizeof(*d_visited)* nSpheres, cudaMemcpyDeviceToHost);
+//             h_cluster = (unsigned int *)malloc(sizeof(*h_cluster) * (nSpheres + 1));
+//             // h_cluster[0] is its size, so it length nSpheres + 1
+//             for (size_t j = 0; i < nSpheres; j++) {
+//                 if (h_visited[j]) {
+//                     h_searched[j] = true;
+//                     h_cluster[h_cluster[0]++] = j;
+//                     gpuErrchk(cudaMemcpy(&h_current_group, &(sphere_data->sphere_group + j), sizeof(SPHERE_GROUP)), cudaMemcpyDeviceToHost);
+//                     if (h_current_group != SPHERE_GROUP::CORE) {
+//                        gpuErrchk(cudaMemset(&(sphere_data->sphere_group + j), SPHERE_GROUP::BORDER, sizeof(*sphere_data->sphere_group)));
+//                     }
+//                 }
+//             }
+//             h_cluster = (unsigned int *)realloc(h_cluster, sizeof(*h_cluster) * (h_cluster[0]));
+//             h_clusters[h_cluster_num] = h_cluster;
+//             h_clusters[0][0] = ++h_cluster_num; // h_clusters size is number of clusters + 1 cause it includes its length 
+//         }
+//     }
+//     h_clusters = (unsigned int *)realloc(h_clusters, sizeof(*h_clusters) * (h_clusters[0][0]));
 
-    free(h_visited);
-    free(h_searched);
-    free(h_border_num);
-    free(h_current_group);
-    gpuErrchk(cudaFree(d_borders));
-    gpuErrchk(cudaFree(d_border_num));
-    gpuErrchk(cudaFree(d_visited));
-    return(h_clusters);
-}
+//     free(h_visited);
+//     free(h_searched);
+//     free(h_border_num);
+//     free(h_current_group);
+//     gpuErrchk(cudaFree(d_borders));
+//     gpuErrchk(cudaFree(d_border_num));
+//     gpuErrchk(cudaFree(d_visited));
+//     return(h_clusters);
+// }
 
 /// computes h_cluster by breadth first search
 static __global__ void cluster_search_BFS_kernel(unsigned int nSpheres,
@@ -292,52 +292,52 @@ static __global__ void update_cluster_group(ChSystemGpu_impl::GranSphereDataPtr 
     }
 }
 
-/// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
-/// min_pts: minimal number of points for a cluster
-static __host__ void gdbscan_search_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                           ChSystemGpu_impl::GranParamsPtr gran_params,
-                                           unsigned int nSpheres, size_t min_pts) {
-    unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
+// /// G-DBSCAN; density-based h_clustering algorithm. Identifies core, border and noise points in h_clusters.
+// /// min_pts: minimal number of points for a cluster
+// static __host__ void gdbscan_search_graph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+//                                            ChSystemGpu_impl::GranParamsPtr gran_params,
+//                                            unsigned int nSpheres, size_t min_pts) {
+//     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
-    init_sphere_group_gdbscan<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
-                sphere_data->adj_num, sphere_data->sphere_group, minPts);
+//     init_sphere_group_gdbscan<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres,
+//                 sphere_data->adj_num, sphere_data->sphere_group, minPts);
 
-    unsigned int h_clusters * cluster_search_BFS(nSpheres, sphere_data->adj_num,
-                                        sphere_data->adj_start,
-                                        sphere_data->adj_list,
-                                        sphere_data->sphere_group);
+//     unsigned int h_clusters * cluster_search_BFS(nSpheres, sphere_data->adj_num,
+//                                         sphere_data->adj_start,
+//                                         sphere_data->adj_list,
+//                                         sphere_data->sphere_group);
 
-    unsigned int * d_cluster;
-    unsigned int cluster_num = h_clusters[0][0];
-    unsigned int sphere_num_in_cluster;
-    unsigned int biggest_cluster_size = 1;
-    unsigned int biggest_cluster_id = 1;
+//     unsigned int * d_cluster;
+//     unsigned int cluster_num = h_clusters[0][0];
+//     unsigned int sphere_num_in_cluster;
+//     unsigned int biggest_cluster_size = 1;
+//     unsigned int biggest_cluster_id = 1;
 
-    // find biggest cluster id
-    for (size_t i = 0; i <  cluster_num, i++) {// expect low number of clusters, 1 most of the time, maybe 2-3 otherwise.
-        sphere_num_in_cluster = h_clusters[i][0];
-        if (sphere_num_in_cluster > biggest_cluster_size) {
-            biggest_cluster_size = sphere_num_in_cluster;
-            biggest_cluster_id = i;
-        }
-    }    
+//     // find biggest cluster id
+//     for (size_t i = 0; i <  cluster_num, i++) {// expect low number of clusters, 1 most of the time, maybe 2-3 otherwise.
+//         sphere_num_in_cluster = h_clusters[i][0];
+//         if (sphere_num_in_cluster > biggest_cluster_size) {
+//             biggest_cluster_size = sphere_num_in_cluster;
+//             biggest_cluster_id = i;
+//         }
+//     }    
 
-    // tag each sphere to a cluster_group
-    for (size_t i = 1; i < h_cluster_num; i++) {// expect low number of clusters, 1 most of the time, maybe 2-3 otherwise.
-        unsigned int cluster_id = (biggest_cluster == i) ? CLUSTER_GROUP::GROUND : i;
-        gpuErrchk(cudaMalloc(&d_cluster, h_clusters[i][0]));
-        gpuErrchk(cudaMemcpy(d_cluster, h_clusters[i] + 1, sizeof(*d_cluster) * h_clusters[i][0]));
-        sphere_num_in_cluster = h_clusters[i][0];
-        update_cluster_group<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data,
-                                            gran_params, sphere_num_in_cluster,
-                                            cluster_id, d_cluster);
-        gpuErrchk(cudaFree(d_cluster));
-    }
+//     // tag each sphere to a cluster_group
+//     for (size_t i = 1; i < h_cluster_num; i++) {// expect low number of clusters, 1 most of the time, maybe 2-3 otherwise.
+//         unsigned int cluster_id = (biggest_cluster == i) ? CLUSTER_GROUP::GROUND : i;
+//         gpuErrchk(cudaMalloc(&d_cluster, h_clusters[i][0]));
+//         gpuErrchk(cudaMemcpy(d_cluster, h_clusters[i] + 1, sizeof(*d_cluster) * h_clusters[i][0]));
+//         sphere_num_in_cluster = h_clusters[i][0];
+//         update_cluster_group<<<nBLocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data,
+//                                             gran_params, sphere_num_in_cluster,
+//                                             cluster_id, d_cluster);
+//         gpuErrchk(cudaFree(d_cluster));
+//     }
 
-    for (size_t i = 0; i < h_clusters[0][0]) {
-        free(h_clusters[i]);
-    }
-    free(h_clusters);
-}
+//     for (size_t i = 0; i < h_clusters[0][0]) {
+//         free(h_clusters[i]);
+//     }
+//     free(h_clusters);
+// }
 
 /// @} gpu_cuda

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -325,6 +325,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
 
             // Convert to not_stupid_bool
             sphere_fixed.at(i) = (not_stupid_bool)((user_provided_fixed) ? user_sphere_fixed[i] : false);
+            // default sphere group/cluster
             sphere_group.at(i) = SPHERE_GROUP::CORE;
             sphere_group.at(i) = CLUSTER_INDEX::START;
             if (user_provided_vel) {

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -86,13 +86,6 @@ __host__ std::vector<float3> ChSystemGpu_impl::get_max_z_map(unsigned int x_size
     return max_z_map;
 }
 
-// TODO: Parallellize
-__host__ void ChSystemGpu_impl::reset_ground_group() {
-    for (size_t index = 0; index < nSpheres; index++) {
-        sphere_data->sphere_group[index] = SPHERE_GROUP::CORE;
-    }
-}
-
 // Reset broadphase data structures
 void ChSystemGpu_impl::resetBroadphaseInformation() {
     // Set all the offsets to zero

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -272,7 +272,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
 
     TRACK_VECTOR_RESIZE(sphere_fixed, nSpheres, "sphere_fixed", 0);
     TRACK_VECTOR_RESIZE(sphere_group, nSpheres, "sphere_group", SPHERE_GROUP::CORE);
-    TRACK_VECTOR_RESIZE(sphere_cluster, nSpheres, "sphere_cluster", 1);
+    TRACK_VECTOR_RESIZE(sphere_cluster, nSpheres, "sphere_cluster", static_cast<unsigned int>(CLUSTER_INDEX::GROUND));
     TRACK_VECTOR_RESIZE(sphere_inside_mesh, nSpheres, "sphere_inside_mesh", false);
 
     TRACK_VECTOR_RESIZE(pos_X_dt, nSpheres, "pos_X_dt", 0);
@@ -309,7 +309,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
             sphere_fixed.at(i) = (not_stupid_bool)((user_provided_fixed) ? user_sphere_fixed[i] : false);
             // default sphere group/cluster
             sphere_group.at(i) = SPHERE_GROUP::CORE;
-            sphere_cluster.at(i) = (unsigned int)CLUSTER_INDEX::START;
+            sphere_cluster.at(i) = static_cast<unsigned int>(CLUSTER_INDEX::START);
             sphere_inside_mesh.at(i) = false;
             if (user_provided_vel) {
                 auto vel = user_sphere_vel.at(i);

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -567,8 +567,10 @@ __host__ double ChSystemGpu_impl::AdvanceSimulation(float duration) {
             const unsigned int nThreadsUpdateHist = 2 * CUDA_THREADS_PER_BLOCK;
             unsigned int fricMapSize = nSpheres * MAX_SPHERES_TOUCHED_BY_SPHERE;
             unsigned int nBlocksFricHistoryPostProcess = (fricMapSize + nThreadsUpdateHist - 1) / nThreadsUpdateHist;
-            updateFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(fricMapSize, sphere_data,
-                                                                                      gran_params);
+            updateInactiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
+                fricMapSize, sphere_data, gran_params);
+            resetActiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
+                fricMapSize, sphere_data, gran_params);
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
             updateAngVels<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(stepSize_SU, sphere_data, nSpheres, gran_params);

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -581,7 +581,7 @@ __host__ double ChSystemGpu_impl::AdvanceSimulation(float duration) {
                     cub::DeviceScan::InclusiveSum(d_temp_storage, bytesize,
                         sphere_data->adj_start,
                         sphere_data->adj_start, gran_params->nSpheres);
-                    gpuErrchk(cudaFree(d_temp_storage));
+                    // gpuErrchk(cudaFree(d_temp_storage));
                     break;
                 }
 

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -548,7 +548,7 @@ __host__ double ChSystemGpu_impl::AdvanceSimulation(float duration) {
         } else if (gran_params->friction_mode == CHGPU_FRICTION_MODE::SINGLE_STEP ||
                    gran_params->friction_mode == CHGPU_FRICTION_MODE::MULTI_STEP) {
 
-            // figure out who is contacting + graph construction if CLUSTER_ enums enabled
+            // figure out who is contacting
             determineContactPairs<<<nSDs, MAX_COUNT_OF_SPHERES_PER_SD>>>(sphere_data, gran_params);
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -545,7 +545,6 @@ __host__ double ChSystemGpu_impl::AdvanceSimulation(float duration) {
             gpuErrchk(cudaDeviceSynchronize());
         } else if (gran_params->friction_mode == CHGPU_FRICTION_MODE::SINGLE_STEP ||
                    gran_params->friction_mode == CHGPU_FRICTION_MODE::MULTI_STEP) {
-
             // figure out who is contacting
             determineContactPairs<<<nSDs, MAX_COUNT_OF_SPHERES_PER_SD>>>(sphere_data, gran_params);
             gpuErrchk(cudaPeekAtLastError());
@@ -558,7 +557,7 @@ __host__ double ChSystemGpu_impl::AdvanceSimulation(float duration) {
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
         }
-        
+
         METRICS_PRINTF("Starting integrateSpheres!\n");
         integrateSpheres<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(stepSize_SU, sphere_data, nSpheres, gran_params);
         gpuErrchk(cudaPeekAtLastError());

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -193,7 +193,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
     std::vector<float, cudallocator<float>> sphere_vel_z_tmp;
 
     std::vector<unsigned int, cudallocator<unsigned int>> adj_num_tmp;
-    std::vector<unsigned int, cudallocator<unsigned int>> adj_start_tmp;
+    std::vector<unsigned int, cudallocator<unsigned int>> adj_offset_tmp;
     std::vector<unsigned int, cudallocator<unsigned int>> adj_list_tmp;
 
     std::vector<not_stupid_bool, cudallocator<not_stupid_bool>> sphere_fixed_tmp;
@@ -261,7 +261,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
 
     // Allocate space for connectivity graph
     TRACK_VECTOR_RESIZE(adj_num, nSpheres, "adj_num", 0);
-    TRACK_VECTOR_RESIZE(adj_start, nSpheres, "adj_start", 0);
+    TRACK_VECTOR_RESIZE(adj_offset, nSpheres, "adj_offset", 0);
     TRACK_VECTOR_RESIZE(adj_list, (nSpheres * MAX_SPHERES_TOUCHED_BY_SPHERE), "adj_list", 0);
 
     TRACK_VECTOR_RESIZE(sphere_owner_SDs, nSpheres, "sphere_owner_SDs", NULL_CHGPU_ID);

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -307,7 +307,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
 
             // Convert to not_stupid_bool
             sphere_fixed.at(i) = (not_stupid_bool)((user_provided_fixed) ? user_sphere_fixed[i] : false);
-            // default sphere group/cluster
+            // default sphere type/cluster
             sphere_type.at(i) = SPHERE_TYPE::CORE;
             sphere_cluster.at(i) = static_cast<unsigned int>(CLUSTER_INDEX::START);
             sphere_inside_mesh.at(i) = false;

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -57,7 +57,7 @@ __host__ std::vector<float3> ChSystemGpu_impl::get_max_z_map(unsigned int x_size
 
     size_t nSpheres = sphere_local_pos_Z.size();
     for (size_t index = 0; index < nSpheres; index++) {
-        if (sphere_data->sphere_group[index] == SPHERE_GROUP::CORE) {
+        if (sphere_data->sphere_cluster[index] == SPHERE_CLUSTER::GROUND) {
             unsigned int ownerSD = sphere_data->sphere_owner_SDs[index];
             unsigned int spheresTouchingThisSD = sphere_data->SD_NumSpheresTouching[ownerSD];
             if (spheresTouchingThisSD < 5) {

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -197,7 +197,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
     std::vector<unsigned int, cudallocator<unsigned int>> adj_list_tmp;
 
     std::vector<not_stupid_bool, cudallocator<not_stupid_bool>> sphere_fixed_tmp;
-    std::vector<SPHERE_GROUP, cudallocator<SPHERE_GROUP>> sphere_group_tmp;
+    std::vector<SPHERE_TYPE, cudallocator<SPHERE_TYPE>> sphere_type_tmp;
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_cluster_tmp;
     std::vector<not_stupid_bool, cudallocator<not_stupid_bool>> sphere_inside_mesh_tmp;
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_owner_SDs_tmp;
@@ -211,7 +211,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
     sphere_vel_z_tmp.resize(nSpheres);
 
     sphere_fixed_tmp.resize(nSpheres);
-    sphere_group_tmp.resize(nSpheres);
+    sphere_type_tmp.resize(nSpheres);
     sphere_cluster_tmp.resize(nSpheres);
     sphere_inside_mesh_tmp.resize(nSpheres);
     sphere_owner_SDs_tmp.resize(nSpheres);
@@ -227,7 +227,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
         sphere_vel_z_tmp.at(i) = (float)pos_Z_dt.at(sphere_ids.at(i));
 
         sphere_fixed_tmp.at(i) = sphere_fixed.at(sphere_ids.at(i));
-        sphere_group_tmp.at(i) = sphere_group.at(sphere_ids.at(i));
+        sphere_type_tmp.at(i) = sphere_type.at(sphere_ids.at(i));
         sphere_cluster_tmp.at(i) = sphere_cluster.at(sphere_ids.at(i));
         sphere_inside_mesh_tmp.at(i) = sphere_inside_mesh.at(sphere_ids.at(i));
         sphere_owner_SDs_tmp.at(i) = sphere_owner_SDs.at(sphere_ids.at(i));
@@ -243,7 +243,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
     pos_Z_dt.swap(sphere_vel_z_tmp);
 
     sphere_fixed.swap(sphere_fixed_tmp);
-    sphere_group.swap(sphere_group_tmp);
+    sphere_type.swap(sphere_type_tmp);
     sphere_cluster.swap(sphere_cluster_tmp);
     sphere_inside_mesh.swap(sphere_inside_mesh_tmp);
     sphere_owner_SDs.swap(sphere_owner_SDs_tmp);
@@ -271,7 +271,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
     TRACK_VECTOR_RESIZE(sphere_local_pos_Z, nSpheres, "sphere_local_pos_Z", 0);
 
     TRACK_VECTOR_RESIZE(sphere_fixed, nSpheres, "sphere_fixed", 0);
-    TRACK_VECTOR_RESIZE(sphere_group, nSpheres, "sphere_group", SPHERE_GROUP::CORE);
+    TRACK_VECTOR_RESIZE(sphere_type, nSpheres, "sphere_type", SPHERE_TYPE::CORE);
     TRACK_VECTOR_RESIZE(sphere_cluster, nSpheres, "sphere_cluster", static_cast<unsigned int>(CLUSTER_INDEX::GROUND));
     TRACK_VECTOR_RESIZE(sphere_inside_mesh, nSpheres, "sphere_inside_mesh", false);
 
@@ -308,7 +308,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
             // Convert to not_stupid_bool
             sphere_fixed.at(i) = (not_stupid_bool)((user_provided_fixed) ? user_sphere_fixed[i] : false);
             // default sphere group/cluster
-            sphere_group.at(i) = SPHERE_GROUP::CORE;
+            sphere_type.at(i) = SPHERE_TYPE::CORE;
             sphere_cluster.at(i) = static_cast<unsigned int>(CLUSTER_INDEX::START);
             sphere_inside_mesh.at(i) = false;
             if (user_provided_vel) {

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -206,7 +206,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
     std::vector<not_stupid_bool, cudallocator<not_stupid_bool>> sphere_fixed_tmp;
     std::vector<SPHERE_GROUP, cudallocator<SPHERE_GROUP>> sphere_group_tmp;
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_cluster_tmp;
-    std::vector<bool, cudallocator<bool>> sphere_inside_mesh_tmp;
+    std::vector<not_stupid_bool, cudallocator<not_stupid_bool>> sphere_inside_mesh_tmp;
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_owner_SDs_tmp;
 
     sphere_pos_x_tmp.resize(nSpheres);
@@ -316,6 +316,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
             // default sphere group/cluster
             sphere_group.at(i) = SPHERE_GROUP::CORE;
             sphere_cluster.at(i) = (unsigned int)CLUSTER_INDEX::START;
+            sphere_inside_mesh.at(i) = false;
             if (user_provided_vel) {
                 auto vel = user_sphere_vel.at(i);
                 pos_X_dt.at(i) = (float)(vel.x / VEL_SU2UU);

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -567,9 +567,7 @@ __host__ double ChSystemGpu_impl::AdvanceSimulation(float duration) {
             const unsigned int nThreadsUpdateHist = 2 * CUDA_THREADS_PER_BLOCK;
             unsigned int fricMapSize = nSpheres * MAX_SPHERES_TOUCHED_BY_SPHERE;
             unsigned int nBlocksFricHistoryPostProcess = (fricMapSize + nThreadsUpdateHist - 1) / nThreadsUpdateHist;
-            updateInactiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
-                fricMapSize, sphere_data, gran_params);
-            resetActiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
+            updateFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
                 fricMapSize, sphere_data, gran_params);
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -57,7 +57,7 @@ __host__ std::vector<float3> ChSystemGpu_impl::get_max_z_map(unsigned int x_size
 
     size_t nSpheres = sphere_local_pos_Z.size();
     for (size_t index = 0; index < nSpheres; index++) {
-        if (sphere_data->sphere_cluster[index] == SPHERE_CLUSTER::GROUND) {
+        if (sphere_data->sphere_cluster[index] == static_cast<int>(CLUSTER_INDEX::GROUND)) {
             unsigned int ownerSD = sphere_data->sphere_owner_SDs[index];
             unsigned int spheresTouchingThisSD = sphere_data->SD_NumSpheresTouching[ownerSD];
             if (spheresTouchingThisSD < 5) {
@@ -216,6 +216,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
     sphere_inside_mesh_tmp.resize(nSpheres);
     sphere_owner_SDs_tmp.resize(nSpheres);
 
+    // reorder values into new sorted
     for (unsigned int i = 0; i < nSpheres; i++) {
         sphere_pos_x_tmp.at(i) = sphere_local_pos_X.at(sphere_ids.at(i));
         sphere_pos_y_tmp.at(i) = sphere_local_pos_Y.at(sphere_ids.at(i));

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -252,7 +252,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
     INFO_PRINTF("%u balls added!\n", nSpheres);
     gran_params->nSpheres = nSpheres;
     contact_total = 0;
-    
+
     // Allocate space for connectivity graph
     TRACK_VECTOR_RESIZE(adj_num, nSpheres, "adj_num", 0);
     TRACK_VECTOR_RESIZE(adj_start, nSpheres, "adj_start", 0);

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cu
@@ -206,6 +206,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
     std::vector<not_stupid_bool, cudallocator<not_stupid_bool>> sphere_fixed_tmp;
     std::vector<SPHERE_GROUP, cudallocator<SPHERE_GROUP>> sphere_group_tmp;
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_cluster_tmp;
+    std::vector<bool, cudallocator<bool>> sphere_inside_mesh_tmp;
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_owner_SDs_tmp;
 
     sphere_pos_x_tmp.resize(nSpheres);
@@ -219,6 +220,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
     sphere_fixed_tmp.resize(nSpheres);
     sphere_group_tmp.resize(nSpheres);
     sphere_cluster_tmp.resize(nSpheres);
+    sphere_inside_mesh_tmp.resize(nSpheres);
     sphere_owner_SDs_tmp.resize(nSpheres);
 
     for (unsigned int i = 0; i < nSpheres; i++) {
@@ -233,6 +235,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
         sphere_fixed_tmp.at(i) = sphere_fixed.at(sphere_ids.at(i));
         sphere_group_tmp.at(i) = sphere_group.at(sphere_ids.at(i));
         sphere_cluster_tmp.at(i) = sphere_cluster.at(sphere_ids.at(i));
+        sphere_inside_mesh_tmp.at(i) = sphere_inside_mesh.at(sphere_ids.at(i));
         sphere_owner_SDs_tmp.at(i) = sphere_owner_SDs.at(sphere_ids.at(i));
     }
 
@@ -248,6 +251,7 @@ __host__ void ChSystemGpu_impl::defragment_initial_positions() {
     sphere_fixed.swap(sphere_fixed_tmp);
     sphere_group.swap(sphere_group_tmp);
     sphere_cluster.swap(sphere_cluster_tmp);
+    sphere_inside_mesh.swap(sphere_inside_mesh_tmp);
     sphere_owner_SDs.swap(sphere_owner_SDs_tmp);
 }
 __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
@@ -275,6 +279,7 @@ __host__ void ChSystemGpu_impl::setupSphereDataStructures() {
     TRACK_VECTOR_RESIZE(sphere_fixed, nSpheres, "sphere_fixed", 0);
     TRACK_VECTOR_RESIZE(sphere_group, nSpheres, "sphere_group", SPHERE_GROUP::CORE);
     TRACK_VECTOR_RESIZE(sphere_cluster, nSpheres, "sphere_cluster", 1);
+    TRACK_VECTOR_RESIZE(sphere_inside_mesh, nSpheres, "sphere_inside_mesh", false);
 
     TRACK_VECTOR_RESIZE(pos_X_dt, nSpheres, "pos_X_dt", 0);
     TRACK_VECTOR_RESIZE(pos_Y_dt, nSpheres, "pos_Y_dt", 0);

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cuh
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cuh
@@ -554,10 +554,8 @@ static __global__ void determineContactPairs(ChSystemGpu_impl::GranSphereDataPtr
         /// This is the CLUSTER_GRAPH_METHOD::CONTACT
         /// i.e. construct_adj_num_start_by_contact 
         /// computes adj_num and adj_start
-        if ((gran_params->cluster_graph_method > CLUSTER_GRAPH_METHOD::NONE) &&
-            (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE) &&
-            (gran_params->cluster_graph_method == CLUSTER_GRAPH_METHOD::CONTACT)) {
-
+        if ((gran_params->cluster_graph_method == CLUSTER_GRAPH_METHOD::CONTACT) &&
+            (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
             sphere_data->adj_num[sphIDs[bodyA]] = ncontacts;
             sphere_data->adj_start[sphIDs[bodyA]] = ncontacts;
         }

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cuh
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cuh
@@ -1021,9 +1021,30 @@ static __global__ void integrateSpheres(const float stepsize_SU,
 }
 
 /**
- * Integrate angular accelerations and reset friction data. ONLY use this with friction on
+ * Reset active friction data. ONLY use this with friction on
  */
-static __global__ void updateFrictionData(unsigned int frictionHistoryMapSize,
+static __global__ void resetActiveFrictionData(unsigned int frictionHistoryMapSize,
+                                          ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                          ChSystemGpu_impl::GranParamsPtr gran_params) {
+    unsigned int offsetInFrictionMap = threadIdx.x + blockIdx.x * blockDim.x;
+
+    if (offsetInFrictionMap < frictionHistoryMapSize) {
+        // look at this map contact slot and reset it if that slot wasn't active last timestep
+        // printf("contact map for sphere %u entry %u is other %u, active %u \t history is %f, %f, %f\n", body_A,
+        //        contact_id, contact_partners[contact_id], contact_active[contact_id],
+        //        contact_history[contact_id].x, contact_history[contact_id].y, contact_history[contact_id].z);
+        // if the contact is not active, reset it
+        if (sphere_data->contact_active_map[offsetInFrictionMap] != false) {
+            // otherwise reset the active bit for the next step
+            sphere_data->contact_active_map[offsetInFrictionMap] = false;
+        }
+    }
+}
+
+/**
+ * Integrate angular accelerations. ONLY use this with friction on
+ */
+static __global__ void updateInactiveFrictionData(unsigned int frictionHistoryMapSize,
                                           ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                           ChSystemGpu_impl::GranParamsPtr gran_params) {
     unsigned int offsetInFrictionMap = threadIdx.x + blockIdx.x * blockDim.x;
@@ -1040,12 +1061,10 @@ static __global__ void updateFrictionData(unsigned int frictionHistoryMapSize,
                 constexpr float3 null_history = {0.f, 0.f, 0.f};
                 sphere_data->contact_history_map[offsetInFrictionMap] = null_history;
             }
-        } else {
-            // otherwise reset the active bit for the next step
-            sphere_data->contact_active_map[offsetInFrictionMap] = false;
         }
     }
 }
+
 
 /**
  * Integrate angular accelerations. Called only when friction is on

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cuh
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cuh
@@ -653,20 +653,8 @@ static __global__ void computeSphereContactForces(ChSystemGpu_impl::GranSphereDa
             if (active_contact) {
                 theirIDList[numActiveContacts] = sphere_data->contact_partners_map[body_A_offset + body_B_offset];
                 contactIDList[numActiveContacts] = body_B_offset;
-                if ((gran_params->cluster_graph_method == CLUSTER_GRAPH_METHOD::CONTACT) &&
-                    (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
-                    if (numActiveContacts <= sphere_data->adj_num[mySphereID]) {
-                        sphere_data->adj_list[sphere_data->adj_start[mySphereID] + numActiveContacts] = theirIDList[numActiveContacts];
-                    } else {
-                        ABORTABORTABORT("adj_list was overran! sphere %d adj_num has %d contacts yet numActiveContacts is %d\n", mySphereID, sphere_data->adj_num[mySphereID], numActiveContacts);
-                    }
-                }
                 numActiveContacts++;
             }
-        }
-
-        if (numActiveContacts != sphere_data->adj_num[mySphereID]) {
-            ABORTABORTABORT("adj_list error! sphere %d adj_num has %d contacts yet numActiveContacts is %d\n", mySphereID, sphere_data->adj_num[mySphereID], numActiveContacts);
         }
 
         // Sort. Simple but should be effective since we have 12 contacts max

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cuh
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cuh
@@ -693,7 +693,7 @@ static __global__ void computeSphereContactForces(ChSystemGpu_impl::GranSphereDa
         if ((gran_params->cluster_graph_method > CLUSTER_GRAPH_METHOD::NONE) &&
             (gran_params->cluster_search_method > CLUSTER_GRAPH_METHOD::NONE) &&
             (gran_params->cluster_graph_method == CLUSTER_GRAPH_METHOD::CONTACT)) {
-            gpuErrchk(cudaMemcpy(&sphere_data->adj_list + sphere_data->adj_start[mySphereID],
+            gpuErrchk(cudaMemcpy(sphere_data->adj_list + sphere_data->adj_start[mySphereID],
                     theirIDList,
                     numActiveContacts,
                     cudaMemcpyHostToDevice));

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cuh
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cuh
@@ -34,7 +34,7 @@
 #include "chrono_gpu/cuda/ChCudaMathUtils.cuh"
 #include "chrono_gpu/cuda/ChGpuHelpers.cuh"
 #include "chrono_gpu/cuda/ChGpuBoundaryConditions.cuh"
-#include "chrono_gpu/cuda/ChGpuClustering.cuh"
+// #include "chrono_gpu/cuda/ChGpuClustering.cuh"
 
 using chrono::gpu::ChSystemGpu_impl;
 

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cuh
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cuh
@@ -474,7 +474,6 @@ inline __device__ void applyExternalForces(unsigned int currSphereID,
 
 static __global__ void determineContactPairs(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                              ChSystemGpu_impl::GranParamsPtr gran_params) {
-    
     // Cache positions of spheres local to this SD
     __shared__ int3 sphere_pos_local[MAX_COUNT_OF_SPHERES_PER_SD];
     __shared__ unsigned int sphIDs[MAX_COUNT_OF_SPHERES_PER_SD];

--- a/src/chrono_gpu/cuda/ChGpu_SMC.cuh
+++ b/src/chrono_gpu/cuda/ChGpu_SMC.cuh
@@ -41,7 +41,7 @@ using chrono::gpu::ChSystemGpu_impl;
 using chrono::gpu::CHGPU_TIME_INTEGRATOR;
 using chrono::gpu::CHGPU_FRICTION_MODE;
 using chrono::gpu::CHGPU_ROLLING_MODE;
-using chrono::gpu::SPHERE_GROUP;
+using chrono::gpu::SPHERE_TYPE;
 using chrono::gpu::CLUSTER_GRAPH_METHOD;
 using chrono::gpu::CLUSTER_SEARCH_METHOD;
 

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -443,7 +443,7 @@ __host__ void ChSystemGpuMesh_impl::IdentifyClusters() {
         switch (gran_params->cluster_search_method) {
             case CLUSTER_SEARCH_METHOD::BFS: {
                 /// sphere_type is CORE if neighbors_num > min_pts else NOISE
-                GdbscanInitSphereGroup<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
+                GdbscanInitSphereType<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
                     nSpheres,
                     sphere_data->adj_num,
                     sphere_data->sphere_type,
@@ -452,10 +452,10 @@ __host__ void ChSystemGpuMesh_impl::IdentifyClusters() {
                 gpuErrchk(cudaDeviceSynchronize());
 
                 /// finds spheres in volume
-                /// must be set AFTER GdbscanInitSphereGroup,
+                /// must be set AFTER GdbscanInitSphereType,
                 ///  and AFTER interactionGranMat_TriangleSoup,
                 ///  which is AFTER AdvanceSimulation
-                SetVolumeSphereGroup<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
+                SetVolumeSphereType<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
                     sphere_data,
                     nSpheres);
                 gpuErrchk(cudaPeekAtLastError());

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -545,10 +545,6 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
                 gpuErrchk(cudaPeekAtLastError());
                 gpuErrchk(cudaDeviceSynchronize());
 
-                GdbscanInitSphereCluster<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(nSpheres, sphere_data->sphere_cluster, static_cast<unsigned int>(chrono::gpu::CLUSTER_INDEX::GROUND));
-                gpuErrchk(cudaPeekAtLastError());
-                gpuErrchk(cudaDeviceSynchronize());
-
                 GdbscanSearchGraph(sphere_data, gran_params, nSpheres, gran_params->gdbscan_min_pts);
                 break;
             }

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -461,10 +461,10 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
 
-            update_ground_group<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
-                    sphere_data, gran_params, nSpheres);
-            gpuErrchk(cudaPeekAtLastError());
-            gpuErrchk(cudaDeviceSynchronize());
+            // update_ground_group<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
+            //         sphere_data, gran_params, nSpheres);
+            // gpuErrchk(cudaPeekAtLastError());
+            // gpuErrchk(cudaDeviceSynchronize());
 
             computeSphereContactForces<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
                 sphere_data, gran_params, BC_type_list.data(), BC_params_list_SU.data(),

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -490,7 +490,7 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
                     cub::DeviceScan::InclusiveSum(d_temp_storage, bytesize,
                         sphere_data->adj_start,
                         sphere_data->adj_start, gran_params->nSpheres);
-                    gpuErrchk(cudaFree(d_temp_storage));
+                    // gpuErrchk(cudaFree(d_temp_storage));
                     break;
                 }
 

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -418,7 +418,6 @@ __global__ void interactionGranMat_TriangleSoup(ChSystemGpuMesh_impl::TriangleSo
 /// Identifies the clusters according to parameters in gran_params
 /// Not super fast.
 __host__ void ChSystemGpuMesh_impl::IdentifyClusters() {
-    printf("IdentifyClusters");
     // Figure our the number of blocks that need to be launched to cover the box
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -420,7 +420,7 @@ __global__ void interactionGranMat_TriangleSoup(ChSystemGpuMesh_impl::TriangleSo
 }  // end kernel
 
 __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
-    printf("AdvanceSimulation trimesh\n");
+    // printf("AdvanceSimulation trimesh\n");
     // Figure our the number of blocks that need to be launched to cover the box
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
@@ -457,7 +457,7 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
                 (unsigned int)BC_params_list_SU.size());
         } else if (gran_params->friction_mode == CHGPU_FRICTION_MODE::SINGLE_STEP ||
                    gran_params->friction_mode == CHGPU_FRICTION_MODE::MULTI_STEP) {
-            // figure out who is contacting + adj_num
+            // figure out who is contacting + adj_num if CLUSTER_GRAPH_METHOD::CONTACT 
             determineContactPairs<<<nSDs, MAX_COUNT_OF_SPHERES_PER_SD>>>(sphere_data, gran_params);
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
@@ -465,26 +465,12 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
             // computing adj_start from adj_num
             if ((gran_params->cluster_graph_method == CLUSTER_GRAPH_METHOD::CONTACT) 
                 && (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
-                memcpy(sphere_data->adj_start, sphere_data->adj_num, sizeof(*sphere_data->adj_start) * nSpheres);
-                /// all start indices after mySphereID depend on it -> inclusive sum
-
-                void * d_temp_storage = NULL;
-                size_t bytesize = 0;
-                /// with d_temp_storage = NULL, InclusiveSum computes necessary bytesize
-                cub::DeviceScan::ExclusiveSum(d_temp_storage, bytesize,
-                sphere_data->adj_start,
-                sphere_data->adj_start, gran_params->nSpheres);
-                gpuErrchk(cudaMalloc(&d_temp_storage, bytesize));
-                /// Actually perform IncluseSum
-                cub::DeviceScan::ExclusiveSum(d_temp_storage, bytesize,
-                sphere_data->adj_start,
-                sphere_data->adj_start, gran_params->nSpheres);
-                gpuErrchk(cudaFree(d_temp_storage));
+                cluster_adj_num2start(nSpheres, sphere_data->adj_num, sphere_data->adj_start);
             }
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
             
-            // compute contact forces + adj_list
+            // compute contact forces + adj_list if CLUSTER_GRAPH_METHOD::CONTACT
             computeSphereContactForces<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
                 sphere_data, gran_params, BC_type_list.data(), BC_params_list_SU.data(),
                 (unsigned int)BC_params_list_SU.size(), nSpheres);
@@ -534,36 +520,35 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
         elapsedSimTime += (float)(stepSize_SU * TIME_SU2UU);  // Advance current time
     }
 
-        WriteAdjacencyFiles("test");
-        // getchar();
-        gpuErrchk(cudaPeekAtLastError());
-        gpuErrchk(cudaDeviceSynchronize());
+    gpuErrchk(cudaPeekAtLastError());
+    gpuErrchk(cudaDeviceSynchronize());
 
-        printf("CLUSTER SEARCH");
-        // search for clustering after all steps because slow
-        if ((gran_params->cluster_graph_method > CLUSTER_GRAPH_METHOD::NONE) 
-            && (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
-            unsigned int min_pts = 6;
-            float radius = 1.0f;
-            // step 1- Graph construction
-            switch(gran_params->cluster_graph_method) {
-               case CLUSTER_GRAPH_METHOD::PROXIMITY: {
-                   gdbscan_construct_graph(sphere_data, gran_params, nSpheres, min_pts, radius);
-                   break;
-               }
-               default: {break;}
-            }
+    // WriteAdjacencyFiles("test");
+    // getchar();
 
-            // step 2- Search the graph, find the clusters.
-            switch(gran_params->cluster_search_method) {
-                case CLUSTER_SEARCH_METHOD::BFS: {
-                    gdbscan_search_graph(sphere_data, gran_params, nSpheres, min_pts);
-                    break;
-                }
-                default: {break;}
+    // Clustering is slow in general, so should be done after all steps.
+    if ((gran_params->cluster_graph_method > CLUSTER_GRAPH_METHOD::NONE) 
+        && (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
+        unsigned int min_pts = 6;
+        float radius = 1.0f;
+        // step 1- Graph construction
+        switch(gran_params->cluster_graph_method) {
+            case CLUSTER_GRAPH_METHOD::PROXIMITY: {
+                gdbscan_construct_graph(sphere_data, gran_params, nSpheres, min_pts, radius);
+                break;
             }
+            default: {break;}
         }
-        printf("CLSUTER SEARCH OUT");
+        // step 2- Search the graph, find the clusters.
+        switch(gran_params->cluster_search_method) {
+            case CLUSTER_SEARCH_METHOD::BFS: {
+                gdbscan_search_graph(sphere_data, gran_params, nSpheres, min_pts);
+                break;
+            }
+            default: {break;}
+        }
+    }
+
 
     gpuErrchk(cudaPeekAtLastError());
     gpuErrchk(cudaDeviceSynchronize());

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -456,11 +456,12 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
                 (unsigned int)BC_params_list_SU.size());
         } else if (gran_params->friction_mode == CHGPU_FRICTION_MODE::SINGLE_STEP ||
                    gran_params->friction_mode == CHGPU_FRICTION_MODE::MULTI_STEP) {
-            // figure out who is contacting
+            // figure out who is contacting + graph construction if CLUSTER_ enums enabled
             determineContactPairs<<<nSDs, MAX_COUNT_OF_SPHERES_PER_SD>>>(sphere_data, gran_params);
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
 
+            // compute contact forces + graph construction if CLUSTER_ enums enabled
             computeSphereContactForces<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
                 sphere_data, gran_params, BC_type_list.data(), BC_params_list_SU.data(),
                 (unsigned int)BC_params_list_SU.size(), nSpheres);

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -509,8 +509,10 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
             const unsigned int nThreadsUpdateHist = 2 * CUDA_THREADS_PER_BLOCK;
             unsigned int fricMapSize = nSpheres * MAX_SPHERES_TOUCHED_BY_SPHERE;
             unsigned int nBlocksFricHistoryPostProcess = (fricMapSize + nThreadsUpdateHist - 1) / nThreadsUpdateHist;
-            resetActiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(fricMapSize, sphere_data,
-                                                                                      gran_params);
+            resetActiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
+                fricMapSize,
+                sphere_data,
+                gran_params);
         }
 
         METRICS_PRINTF("Starting computeSphereForces!\n");
@@ -563,8 +565,10 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
             const unsigned int nThreadsUpdateHist = 2 * CUDA_THREADS_PER_BLOCK;
             unsigned int fricMapSize = nSpheres * MAX_SPHERES_TOUCHED_BY_SPHERE;
             unsigned int nBlocksFricHistoryPostProcess = (fricMapSize + nThreadsUpdateHist - 1) / nThreadsUpdateHist;
-            updateInactiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(fricMapSize, sphere_data,
-                                                                                      gran_params);
+            updateInactiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
+                fricMapSize,
+                sphere_data,
+                gran_params);
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
             updateAngVels<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(stepSize_SU, sphere_data, nSpheres, gran_params);

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -451,7 +451,6 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
                 (unsigned int)BC_params_list_SU.size());
         } else if (gran_params->friction_mode == CHGPU_FRICTION_MODE::SINGLE_STEP ||
                    gran_params->friction_mode == CHGPU_FRICTION_MODE::MULTI_STEP) {
-
             // figure out who is contacting
             determineContactPairs<<<nSDs, MAX_COUNT_OF_SPHERES_PER_SD>>>(sphere_data, gran_params);
             gpuErrchk(cudaPeekAtLastError());

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -461,11 +461,6 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
 
-            // update_ground_group<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
-            //         sphere_data, gran_params, nSpheres);
-            // gpuErrchk(cudaPeekAtLastError());
-            // gpuErrchk(cudaDeviceSynchronize());
-
             computeSphereContactForces<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
                 sphere_data, gran_params, BC_type_list.data(), BC_params_list_SU.data(),
                 (unsigned int)BC_params_list_SU.size(), nSpheres);

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -464,12 +464,12 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
             // computing adj_num and adj_start
             if ((gran_params->cluster_graph_method == CLUSTER_GRAPH_METHOD::CONTACT) 
                 && (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
-                cluster_contact_adj_num<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data,
+                ComputeAdjNumByContact<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data,
                                                                  gran_params, nSpheres);
                 gpuErrchk(cudaPeekAtLastError());
                 gpuErrchk(cudaDeviceSynchronize());
 
-                cluster_adj_num2start(nSpheres, sphere_data->adj_num, sphere_data->adj_start);
+                ComputeAdjStartFromAdjNum(nSpheres, sphere_data->adj_num, sphere_data->adj_start);
             }
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());
@@ -537,7 +537,7 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
         // step 1- Graph construction
         switch(gran_params->cluster_graph_method) {
             case CLUSTER_GRAPH_METHOD::PROXIMITY: {
-                gdbscan_construct_graph(sphere_data, gran_params, nSpheres, min_pts, radius);
+                GdbscanConstructGraph(sphere_data, gran_params, nSpheres, min_pts, radius);
                 break;
             }
             default: {break;}
@@ -545,7 +545,7 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
         // step 2- Search the graph, find the clusters.
         switch(gran_params->cluster_search_method) {
             case CLUSTER_SEARCH_METHOD::BFS: {
-                gdbscan_search_graph(sphere_data, gran_params, nSpheres, min_pts);
+                GdbscanSearchGraph(sphere_data, gran_params, nSpheres, min_pts);
                 break;
             }
             default: {break;}

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -402,8 +402,6 @@ __global__ void interactionGranMat_TriangleSoup(ChSystemGpuMesh_impl::TriangleSo
         }  // end of per-triangle loop
         if (sphere_inside_mesh) {
             sphere_data->sphere_group[sphereIDGlobal] = SPHERE_GROUP::VOLUME;
-        } else {
-            sphere_data->sphere_group[sphereIDGlobal] = SPHERE_GROUP::GROUND; // TODO add proper logic
         }
 
         // write back sphere forces
@@ -465,6 +463,15 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
             computeSphereContactForces<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
                 sphere_data, gran_params, BC_type_list.data(), BC_params_list_SU.data(),
                 (unsigned int)BC_params_list_SU.size(), nSpheres);
+        }
+        gpuErrchk(cudaPeekAtLastError());
+        gpuErrchk(cudaDeviceSynchronize());
+
+        if ((gran_params->cluster_graph_method > CLUSTER_GRAPH_METHOD::NONE) 
+            && (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
+            // TODO: graph construction method switch
+
+            // TODO: search method switch
         }
         gpuErrchk(cudaPeekAtLastError());
         gpuErrchk(cudaDeviceSynchronize());

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -509,10 +509,12 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
             const unsigned int nThreadsUpdateHist = 2 * CUDA_THREADS_PER_BLOCK;
             unsigned int fricMapSize = nSpheres * MAX_SPHERES_TOUCHED_BY_SPHERE;
             unsigned int nBlocksFricHistoryPostProcess = (fricMapSize + nThreadsUpdateHist - 1) / nThreadsUpdateHist;
-            resetActiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
+            updateFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
                 fricMapSize,
                 sphere_data,
                 gran_params);
+            gpuErrchk(cudaPeekAtLastError());
+            gpuErrchk(cudaDeviceSynchronize());
         }
 
         METRICS_PRINTF("Starting computeSphereForces!\n");
@@ -565,12 +567,6 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
             const unsigned int nThreadsUpdateHist = 2 * CUDA_THREADS_PER_BLOCK;
             unsigned int fricMapSize = nSpheres * MAX_SPHERES_TOUCHED_BY_SPHERE;
             unsigned int nBlocksFricHistoryPostProcess = (fricMapSize + nThreadsUpdateHist - 1) / nThreadsUpdateHist;
-            updateInactiveFrictionData<<<nBlocksFricHistoryPostProcess, nThreadsUpdateHist>>>(
-                fricMapSize,
-                sphere_data,
-                gran_params);
-            gpuErrchk(cudaPeekAtLastError());
-            gpuErrchk(cudaDeviceSynchronize());
             updateAngVels<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(stepSize_SU, sphere_data, nSpheres, gran_params);
             gpuErrchk(cudaPeekAtLastError());
             gpuErrchk(cudaDeviceSynchronize());

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -15,6 +15,7 @@
 #include "chrono/core/ChMathematics.h"
 #include "chrono_gpu/ChGpuDefines.h"
 #include "chrono_gpu/cuda/ChGpu_SMC_trimesh.cuh"
+#include "chrono_gpu/cuda/ChGpuClustering.cuh"
 #include "chrono_gpu/cuda/ChGpu_SMC.cuh"
 #include "chrono_gpu/physics/ChSystemGpuMesh_impl.h"
 #include "chrono_thirdparty/cub/device/device_reduce.cuh"
@@ -470,25 +471,43 @@ __host__ double ChSystemGpuMesh_impl::AdvanceSimulation(float duration) {
         // clustering mostly takes place here. 
         if ((gran_params->cluster_graph_method > CLUSTER_GRAPH_METHOD::NONE) 
             && (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
+            unsigned int min_pts = 4;
+            float radius = 1.0f;
             // step 1- Graph construction
             switch(gran_params->cluster_graph_method) {
-                case CLUSTER_GRAPH_METHOD::CONTACT:
-                    // graph construction done in determineContactPairs and computeSphereContactForces
+                case CLUSTER_GRAPH_METHOD::CONTACT: {
+                    /// adj_num computed before. adj_start not summed yet
+                    /// Compute subsequent adj_start indices.
+                    /// all start indices after mySphereID depend on it -> inclusive sum
+                    void * d_temp_storage = NULL;
+                    size_t bytesize = 0;
+                    /// with d_temp_storage = NULL, InclusiveSum computes necessary bytesize
+                    cub::DeviceScan::InclusiveSum(d_temp_storage, bytesize,
+                        sphere_data->adj_start,
+                        sphere_data->adj_start, gran_params->nSpheres);
+                    gpuErrchk(cudaMalloc(&d_temp_storage, bytesize));
+                    /// Actually perform IncluseSum
+                    cub::DeviceScan::InclusiveSum(d_temp_storage, bytesize,
+                        sphere_data->adj_start,
+                        sphere_data->adj_start, gran_params->nSpheres);
+                    gpuErrchk(cudaFree(d_temp_storage));
                     break;
+                }
 
-                case CLUSTER_GRAPH_METHOD::PROXIMITY:
+                case CLUSTER_GRAPH_METHOD::PROXIMITY: {
                     gdbscan_construct_graph(sphere_data, gran_params, nSpheres, min_pts, radius);
-                default:
                     break;
+                }
+                default: {break;}
             }
 
             // step 2- Search the graph, find the clusters.
             switch(gran_params->cluster_search_method) {
-                case CLUSTER_SEARCH_METHOD::BFS:
+                case CLUSTER_SEARCH_METHOD::BFS: {
                     gdbscan_search_graph(sphere_data, gran_params, nSpheres, min_pts);
                     break;
-                default:
-                    break;
+                }
+                default: {break;}
             }
         }
 

--- a/src/chrono_gpu/physics/ChSystemGpu.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu.cpp
@@ -541,7 +541,10 @@ void ChSystemGpu::SetParticlePositions(const std::vector<ChVector<float>>& point
 
 void ChSystemGpuMesh::Initialize() {
     ChSystemGpuMesh_impl* sys_trimesh = static_cast<ChSystemGpuMesh_impl*>(m_sys);
+    // std::cout << "initializeSpheres" << std::endl;
+    printf("initializeSpheres\n");
     sys_trimesh->initializeSpheres();
+    printf("initializeTriangles\n");
     sys_trimesh->initializeTriangles();
 }
 

--- a/src/chrono_gpu/physics/ChSystemGpu.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu.cpp
@@ -537,7 +537,6 @@ void ChSystemGpu::SetParticlePositions(const std::vector<ChVector<float>>& point
 
 void ChSystemGpuMesh::Initialize() {
     ChSystemGpuMesh_impl* sys_trimesh = static_cast<ChSystemGpuMesh_impl*>(m_sys);
-    // std::cout << "initializeSpheres" << std::endl;
     sys_trimesh->initializeSpheres();
     sys_trimesh->initializeTriangles();
 }

--- a/src/chrono_gpu/physics/ChSystemGpu.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu.cpp
@@ -64,6 +64,14 @@ void ChSystemGpu::SetOutputFlags(unsigned char flags) {
     m_sys->output_flags = flags;
 }
 
+void ChSystemGpu::SetClusterSearchMethod(CLUSTER_SEARCH_METHOD flag) {
+    m_sys->gran_params->cluster_search_method = flag;
+}
+
+void ChSystemGpu::SetClusterGraphMethod(CLUSTER_GRAPH_METHOD flag) {
+    m_sys->gran_params->cluster_graph_method = flag;
+}
+
 void ChSystemGpu::SetFixedStepSize(float size_UU) {
     m_sys->stepSize_UU = size_UU;
 }

--- a/src/chrono_gpu/physics/ChSystemGpu.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu.cpp
@@ -555,6 +555,13 @@ void ChSystemGpu::Initialize() {
 
 // -----------------------------------------------------------------------------
 
+void ChSystemGpuMesh::IdentifyClusters() {
+    ChSystemGpuMesh_impl* sys_trimesh = static_cast<ChSystemGpuMesh_impl*>(m_sys);
+    sys_trimesh->IdentifyClusters();
+}
+
+// -----------------------------------------------------------------------------
+
 double ChSystemGpuMesh::AdvanceSimulation(float duration) {
     ChSystemGpuMesh_impl* sys_trimesh = static_cast<ChSystemGpuMesh_impl*>(m_sys);
     return sys_trimesh->AdvanceSimulation(duration);

--- a/src/chrono_gpu/physics/ChSystemGpu.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu.cpp
@@ -333,10 +333,6 @@ std::vector<float3> ChSystemGpu::get_max_z_map(unsigned int x_size, unsigned int
     return m_sys->get_max_z_map(x_size, y_size);
 }
 
-void ChSystemGpu::reset_ground_group() {
-    m_sys->reset_ground_group();
-}
-
 size_t ChSystemGpu::EstimateMemUsage() const {
     return m_sys->EstimateMemUsage();
 }

--- a/src/chrono_gpu/physics/ChSystemGpu.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu.cpp
@@ -538,9 +538,7 @@ void ChSystemGpu::SetParticlePositions(const std::vector<ChVector<float>>& point
 void ChSystemGpuMesh::Initialize() {
     ChSystemGpuMesh_impl* sys_trimesh = static_cast<ChSystemGpuMesh_impl*>(m_sys);
     // std::cout << "initializeSpheres" << std::endl;
-
     sys_trimesh->initializeSpheres();
-
     sys_trimesh->initializeTriangles();
 }
 

--- a/src/chrono_gpu/physics/ChSystemGpu.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu.cpp
@@ -542,9 +542,9 @@ void ChSystemGpu::SetParticlePositions(const std::vector<ChVector<float>>& point
 void ChSystemGpuMesh::Initialize() {
     ChSystemGpuMesh_impl* sys_trimesh = static_cast<ChSystemGpuMesh_impl*>(m_sys);
     // std::cout << "initializeSpheres" << std::endl;
-    printf("initializeSpheres\n");
+
     sys_trimesh->initializeSpheres();
-    printf("initializeTriangles\n");
+
     sys_trimesh->initializeTriangles();
 }
 

--- a/src/chrono_gpu/physics/ChSystemGpu.h
+++ b/src/chrono_gpu/physics/ChSystemGpu.h
@@ -183,9 +183,6 @@ class CH_GPU_API ChSystemGpu {
     /// Get map of the max z positions of the spheres
     std::vector<float3> get_max_z_map(unsigned int x_size, unsigned int y_size) const;
 
-    /// Reset all particles to be ground group
-    void reset_ground_group();
-
     /// Return particle position.
     ChVector<float> GetParticlePosition(int nSphere) const;
 

--- a/src/chrono_gpu/physics/ChSystemGpu.h
+++ b/src/chrono_gpu/physics/ChSystemGpu.h
@@ -65,6 +65,10 @@ class CH_GPU_API ChSystemGpu {
     /// Set output settings bit flags by bitwise ORing settings in CHGPU_OUTPUT_FLAGS.
     void SetOutputFlags(unsigned char flags);
 
+    /// Set graph construction method in gran_params with a CLUSTER_GRAPH_METHOD
+    void SetClusterGraphMethod(CLUSTER_GRAPH_METHOD flag);
+    void SetClusterSearchMethod(CLUSTER_SEARCH_METHOD flag);
+
     /// Set timestep size.
     void SetFixedStepSize(float size_UU);
 

--- a/src/chrono_gpu/physics/ChSystemGpu.h
+++ b/src/chrono_gpu/physics/ChSystemGpu.h
@@ -301,6 +301,11 @@ class CH_GPU_API ChSystemGpuMesh : public ChSystemGpu {
     /// Requires Initialize() to have been called.
     virtual double AdvanceSimulation(float duration) override;
 
+    /// Finds particle clusters to identify the Ground, Volume and others
+    /// Constructs a graph using cluster_graph_method and
+    /// searches it with cluster_searchs_method in gran_params
+    virtual void IdentifyClusters();
+
     /// Collect contact forces exerted on all meshes by the granular system.
     void CollectMeshContactForces(std::vector<ChVector<>>& forces, std::vector<ChVector<>>& torques);
 

--- a/src/chrono_gpu/physics/ChSystemGpuMesh_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpuMesh_impl.h
@@ -156,6 +156,11 @@ class ChSystemGpuMesh_impl : public ChSystemGpu_impl {
 
     static void ApplyFrameTransform(float3& p, float* pos, float* rot_mat);
 
+    /// Finds particle clusters to identify the Ground, Volume and others
+    /// Constructs a graph using cluster_graph_method and
+    /// searches it with cluster_searchs_method in gran_params
+    virtual void IdentifyClusters();
+
     /// Advance simulation by duration in user units, return actual duration elapsed.
     /// Requires initialize() to have been called.
     virtual double AdvanceSimulation(float duration) override;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -515,8 +515,7 @@ void ChSystemGpu_impl::WriteFile(
 
 void ChSystemGpu_impl::WriteAdjacencyFiles(std::string ofile) const {
     if (gran_params->cluster_graph_method == CLUSTER_GRAPH_METHOD::NONE) {
-        printf("ERROR: no cluster search method set, no adjacency!\n");
-        exit(1);
+        printf("ERROR: no cluster search method set, no adjacency! Not writing file.\n");
     } else {
         std::ofstream ptFilenum(ofile + "_adj_num_start.csv", std::ios::out);
         std::ostringstream adj_num_strstream;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -82,7 +82,7 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
     gran_params->gdbscan_min_pts = 3;
 
     this->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
-    this->output_flags = CHGPU_OUTPUT_FLAGS::ABSV |  CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS;
+    this->output_flags = ABSV | ANG_VEL_COMPONENTS | CLUSTER | ADJACENCY;
 
     gran_params->max_safe_vel = (float)UINT_MAX;
 
@@ -238,7 +238,7 @@ void ChSystemGpu_impl::WriteFile(
             ptFile.write((const char*)&y_UU, sizeof(float));
             ptFile.write((const char*)&z_UU, sizeof(float));
 
-            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::VEL_COMPONENTS)) {
+            if (GET_OUTPUT_SETTING(VEL_COMPONENTS)) {
                 float vx_UU = (float)(pos_X_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
                 float vy_UU = (float)(pos_Y_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
                 float vz_UU = (float)(pos_Z_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
@@ -248,7 +248,7 @@ void ChSystemGpu_impl::WriteFile(
                 ptFile.write((const char*)&vz_UU, sizeof(float));
             }
 
-            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ABSV)) {
+            if (GET_OUTPUT_SETTING(ABSV)) {
                 float absv = (float)(std::sqrt(pos_X_dt.at(n) * pos_X_dt.at(n) + pos_Y_dt.at(n) * pos_Y_dt.at(n) +
                                                pos_Z_dt.at(n) * pos_Z_dt.at(n)) *
                                      VEL_SU2UU);
@@ -257,7 +257,7 @@ void ChSystemGpu_impl::WriteFile(
             }
 
             if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS &&
-                GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS)) {
+                GET_OUTPUT_SETTING(ANG_VEL_COMPONENTS)) {
                 float omega_x_UU = (float)(sphere_Omega_X.at(n) / TIME_SU2UU);
                 float omega_y_UU = (float)(sphere_Omega_Y.at(n) / TIME_SU2UU);
                 float omega_z_UU = (float)(sphere_Omega_Z.at(n) / TIME_SU2UU);
@@ -273,30 +273,30 @@ void ChSystemGpu_impl::WriteFile(
         // Dump to a stream, write to file only at end
         std::ostringstream outstrstream;
         outstrstream << "x,y,z";
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::VEL_COMPONENTS)) {
+        if (GET_OUTPUT_SETTING(VEL_COMPONENTS)) {
             outstrstream << ",vx,vy,vz";
         }
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ABSV)) {
+        if (GET_OUTPUT_SETTING(ABSV)) {
             outstrstream << ",absv";
         }
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FIXITY)) {
+        if (GET_OUTPUT_SETTING(FIXITY)) {
             outstrstream << ",fixed";
         }
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::GROUP)) {
+        if (GET_OUTPUT_SETTING(GROUP)) {
             outstrstream << ",group";
         }
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::CLUSTER)) {
+        if (GET_OUTPUT_SETTING(CLUSTER)) {
             outstrstream << ",cluster";
         }
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ADJACENCY)) {
+        if (GET_OUTPUT_SETTING(ADJACENCY)) {
             outstrstream << ",adj_num";
         }
 
-        if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS && GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS)) {
+        if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS && GET_OUTPUT_SETTING(ANG_VEL_COMPONENTS)) {
             outstrstream << ",wx,wy,wz";
         }
 
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FORCE_COMPONENTS)) {
+        if (GET_OUTPUT_SETTING(FORCE_COMPONENTS)) {
             outstrstream << ",fx,fy,fz";
         }
 
@@ -321,7 +321,7 @@ void ChSystemGpu_impl::WriteFile(
 
             outstrstream << point.x() << "," << point.y() << "," << point.z();
 
-            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::VEL_COMPONENTS)) {
+            if (GET_OUTPUT_SETTING(VEL_COMPONENTS)) {
                 float vx_UU = (float)(pos_X_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
                 float vy_UU = (float)(pos_Y_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
                 float vz_UU = (float)(pos_Z_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
@@ -332,35 +332,35 @@ void ChSystemGpu_impl::WriteFile(
                 outstrstream << "," << velocity.x() << "," << velocity.y() << "," << velocity.z();
             }
 
-            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ABSV)) {
+            if (GET_OUTPUT_SETTING(ABSV)) {
                 float absv = (float)(std::sqrt(pos_X_dt.at(n) * pos_X_dt.at(n) + pos_Y_dt.at(n) * pos_Y_dt.at(n) +
                                                pos_Z_dt.at(n) * pos_Z_dt.at(n)) *
                                      VEL_SU2UU);
                 outstrstream << "," << absv;
             }
 
-            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FIXITY)) {
+            if (GET_OUTPUT_SETTING(FIXITY)) {
                 int fixed = (int)sphere_fixed[n];
                 outstrstream << "," << fixed;
             }
 
-            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::GROUP)) {
+            if (GET_OUTPUT_SETTING(GROUP)) {
                 int group = (int)sphere_group[n];
                 outstrstream << "," << group;
             }
 
-            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::CLUSTER)) {
+            if (GET_OUTPUT_SETTING(CLUSTER)) {
                 int cluster = (int)sphere_cluster[n];
                 outstrstream << "," << cluster;
             }
 
-            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ADJACENCY)) {
+            if (GET_OUTPUT_SETTING(ADJACENCY)) {
                 int adjacency = (int)adj_num[n];
                 outstrstream << "," << adjacency;
             }
 
             if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS &&
-                GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS)) {
+                GET_OUTPUT_SETTING(ANG_VEL_COMPONENTS)) {
                 float avx_UU = sphere_Omega_X.at(n) / TIME_SU2UU;
                 float avy_UU = sphere_Omega_Y.at(n) / TIME_SU2UU;
                 float avz_UU = sphere_Omega_Z.at(n) / TIME_SU2UU;
@@ -372,7 +372,7 @@ void ChSystemGpu_impl::WriteFile(
                              << "," << angular_velocity.z();
             }
 
-            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FORCE_COMPONENTS)) {
+            if (GET_OUTPUT_SETTING(FORCE_COMPONENTS)) {
                 double fx =
                     (sphere_acc_X.at(n) - gran_params->gravAcc_X_SU) * gran_params->sphere_mass_SU * FORCE_SU2UU;
                 double fy =
@@ -449,7 +449,7 @@ void ChSystemGpu_impl::WriteFile(
             delete[] vx, vy, vz;
         }
 
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ABSV)) {
+        if (GET_OUTPUT_SETTING(ABSV)) {
             float* absv = new float[nSpheres];
             for (size_t n = 0; n < nSpheres; n++) {
                 absv[n] = sqrt(pos_X_dt.at(n) * pos_X_dt.at(n) + pos_Y_dt.at(n) * pos_Y_dt.at(n) +
@@ -462,7 +462,7 @@ void ChSystemGpu_impl::WriteFile(
             delete[] absv;
         }
 
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FIXITY)) {
+        if (GET_OUTPUT_SETTING(FIXITY)) {
             unsigned char* fixed = new unsigned char[nSpheres];
             for (size_t n = 0; n < nSpheres; n++) {
                 fixed[n] = (unsigned char)sphere_fixed[n];
@@ -473,7 +473,7 @@ void ChSystemGpu_impl::WriteFile(
             delete[] fixed;
         }
 
-        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::GROUP)) {
+        if (GET_OUTPUT_SETTING(GROUP)) {
             unsigned char* group = new unsigned char[nSpheres];
             for (size_t n = 0; n < nSpheres; n++) {
                 group[n] = sphere_group[n];

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -132,7 +132,6 @@ size_t ChSystemGpu_impl::EstimateMemUsage() const {
 
 void ChSystemGpu_impl::packSphereDataPointers() {
     // Set data from system
-    printf("packSphereDataPointers\n");
     sphere_data->sphere_local_pos_X = sphere_local_pos_X.data();
     sphere_data->sphere_local_pos_Y = sphere_local_pos_Y.data();
     sphere_data->sphere_local_pos_Z = sphere_local_pos_Z.data();
@@ -203,7 +202,6 @@ void ChSystemGpu_impl::packSphereDataPointers() {
             sphere_data->rolling_friction_torque = rolling_friction_torque.data();
         }
     }
-    printf("OUT OF packSphereDataPointers\n");
 }
 
 void ChSystemGpu_impl::WriteFile(
@@ -286,6 +284,9 @@ void ChSystemGpu_impl::WriteFile(
         if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::CLUSTER)) {
             outstrstream << ",cluster";
         }
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ADJACENCY)) {
+            outstrstream << ",adj_num";
+        }
 
         if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS && GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS)) {
             outstrstream << ",wx,wy,wz";
@@ -347,6 +348,10 @@ void ChSystemGpu_impl::WriteFile(
             if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::CLUSTER)) {
                 int cluster = (int)sphere_cluster[n];
                 outstrstream << "," << cluster;
+            }
+            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ADJACENCY)) {
+                int adjacency = (int)adj_num[n];
+                outstrstream << "," << adjacency;
             }
 
             if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS &&

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -169,7 +169,7 @@ void ChSystemGpu_impl::packSphereDataPointers() {
     }
 
     sphere_data->sphere_fixed = sphere_fixed.data();
-    sphere_data->sphere_group = sphere_group.data();
+    sphere_data->sphere_type = sphere_type.data();
     sphere_data->sphere_cluster = sphere_cluster.data();
     sphere_data->sphere_inside_mesh = sphere_inside_mesh.data();
 
@@ -345,7 +345,7 @@ void ChSystemGpu_impl::WriteFile(
             }
 
             if (GET_OUTPUT_SETTING(GROUP)) {
-                int group = (int)sphere_group[n];
+                int group = (int)sphere_type[n];
                 outstrstream << "," << group;
             }
 
@@ -476,7 +476,7 @@ void ChSystemGpu_impl::WriteFile(
         if (GET_OUTPUT_SETTING(GROUP)) {
             unsigned char* group = new unsigned char[nSpheres];
             for (size_t n = 0; n < nSpheres; n++) {
-                group[n] = sphere_group[n];
+                group[n] = sphere_type[n];
             }
             H5::DataSet ds_group = file.createDataSet("group", H5::PredType::NATIVE_UCHAR, dataspace);
             ds_group.write(group, H5::PredType::NATIVE_UCHAR);

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -282,8 +282,8 @@ void ChSystemGpu_impl::WriteFile(
         if (GET_OUTPUT_SETTING(FIXITY)) {
             outstrstream << ",fixed";
         }
-        if (GET_OUTPUT_SETTING(GROUP)) {
-            outstrstream << ",group";
+        if (GET_OUTPUT_SETTING(TYPE)) {
+            outstrstream << ",type";
         }
         if (GET_OUTPUT_SETTING(CLUSTER)) {
             outstrstream << ",cluster";
@@ -344,9 +344,9 @@ void ChSystemGpu_impl::WriteFile(
                 outstrstream << "," << fixed;
             }
 
-            if (GET_OUTPUT_SETTING(GROUP)) {
-                int group = (int)sphere_type[n];
-                outstrstream << "," << group;
+            if (GET_OUTPUT_SETTING(TYPE)) {
+                int type = (int)sphere_type[n];
+                outstrstream << "," << type;
             }
 
             if (GET_OUTPUT_SETTING(CLUSTER)) {
@@ -473,15 +473,15 @@ void ChSystemGpu_impl::WriteFile(
             delete[] fixed;
         }
 
-        if (GET_OUTPUT_SETTING(GROUP)) {
-            unsigned char* group = new unsigned char[nSpheres];
+        if (GET_OUTPUT_SETTING(TYPE)) {
+            unsigned char* type = new unsigned char[nSpheres];
             for (size_t n = 0; n < nSpheres; n++) {
-                group[n] = sphere_type[n];
+                type[n] = sphere_type[n];
             }
-            H5::DataSet ds_group = file.createDataSet("group", H5::PredType::NATIVE_UCHAR, dataspace);
-            ds_group.write(group, H5::PredType::NATIVE_UCHAR);
+            H5::DataSet ds_type = file.createDataSet("type", H5::PredType::NATIVE_UCHAR, dataspace);
+            ds_type.write(type, H5::PredType::NATIVE_UCHAR);
 
-            delete[] group;
+            delete[] type;
         }
 
         if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS && GET_OUTPUT_SETTING(ANG_VEL_COMPONENTS)) {

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -76,10 +76,10 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
     gran_params->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
 
     gran_params->cluster_graph_method = CLUSTER_GRAPH_METHOD::CONTACT;
-    gran_params->cluster_search_method = CLUSTER_GRAPH_METHOD::BFS;
+    gran_params->cluster_search_method = CLUSTER_SEARCH_METHOD::BFS;
 
     this->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
-    this->output_flags = ABSV | ANG_VEL_COMPONENTS;
+    this->output_flags = CHGPU_OUTPUT_FLAGS::ABSV |  CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS;
 
     gran_params->max_safe_vel = (float)UINT_MAX;
 
@@ -234,7 +234,7 @@ void ChSystemGpu_impl::WriteFile(
             ptFile.write((const char*)&y_UU, sizeof(float));
             ptFile.write((const char*)&z_UU, sizeof(float));
 
-            if (GET_OUTPUT_SETTING(VEL_COMPONENTS)) {
+            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::VEL_COMPONENTS)) {
                 float vx_UU = (float)(pos_X_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
                 float vy_UU = (float)(pos_Y_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
                 float vz_UU = (float)(pos_Z_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
@@ -244,7 +244,7 @@ void ChSystemGpu_impl::WriteFile(
                 ptFile.write((const char*)&vz_UU, sizeof(float));
             }
 
-            if (GET_OUTPUT_SETTING(ABSV)) {
+            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ABSV)) {
                 float absv = (float)(std::sqrt(pos_X_dt.at(n) * pos_X_dt.at(n) + pos_Y_dt.at(n) * pos_Y_dt.at(n) +
                                                pos_Z_dt.at(n) * pos_Z_dt.at(n)) *
                                      VEL_SU2UU);
@@ -253,7 +253,7 @@ void ChSystemGpu_impl::WriteFile(
             }
 
             if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS &&
-                GET_OUTPUT_SETTING(ANG_VEL_COMPONENTS)) {
+                GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS)) {
                 float omega_x_UU = (float)(sphere_Omega_X.at(n) / TIME_SU2UU);
                 float omega_y_UU = (float)(sphere_Omega_Y.at(n) / TIME_SU2UU);
                 float omega_z_UU = (float)(sphere_Omega_Z.at(n) / TIME_SU2UU);
@@ -269,27 +269,27 @@ void ChSystemGpu_impl::WriteFile(
         // Dump to a stream, write to file only at end
         std::ostringstream outstrstream;
         outstrstream << "x,y,z";
-        if (GET_OUTPUT_SETTING(VEL_COMPONENTS)) {
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::VEL_COMPONENTS)) {
             outstrstream << ",vx,vy,vz";
         }
-        if (GET_OUTPUT_SETTING(ABSV)) {
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ABSV)) {
             outstrstream << ",absv";
         }
-        if (GET_OUTPUT_SETTING(FIXITY)) {
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FIXITY)) {
             outstrstream << ",fixed";
         }
-        if (GET_OUTPUT_SETTING(GROUP)) {
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::GROUP)) {
             outstrstream << ",group";
         }
-        if (GET_OUTPUT_SETTING(CLUSTER)) {
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::CLUSTER)) {
             outstrstream << ",cluster";
         }
 
-        if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS && GET_OUTPUT_SETTING(ANG_VEL_COMPONENTS)) {
+        if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS && GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS)) {
             outstrstream << ",wx,wy,wz";
         }
 
-        if (GET_OUTPUT_SETTING(FORCE_COMPONENTS)) {
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FORCE_COMPONENTS)) {
             outstrstream << ",fx,fy,fz";
         }
 
@@ -314,7 +314,7 @@ void ChSystemGpu_impl::WriteFile(
 
             outstrstream << point.x() << "," << point.y() << "," << point.z();
 
-            if (GET_OUTPUT_SETTING(VEL_COMPONENTS)) {
+            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::VEL_COMPONENTS)) {
                 float vx_UU = (float)(pos_X_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
                 float vy_UU = (float)(pos_Y_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
                 float vz_UU = (float)(pos_Z_dt[n] * LENGTH_SU2UU / TIME_SU2UU);
@@ -325,30 +325,30 @@ void ChSystemGpu_impl::WriteFile(
                 outstrstream << "," << velocity.x() << "," << velocity.y() << "," << velocity.z();
             }
 
-            if (GET_OUTPUT_SETTING(ABSV)) {
+            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ABSV)) {
                 float absv = (float)(std::sqrt(pos_X_dt.at(n) * pos_X_dt.at(n) + pos_Y_dt.at(n) * pos_Y_dt.at(n) +
                                                pos_Z_dt.at(n) * pos_Z_dt.at(n)) *
                                      VEL_SU2UU);
                 outstrstream << "," << absv;
             }
 
-            if (GET_OUTPUT_SETTING(FIXITY)) {
+            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FIXITY)) {
                 int fixed = (int)sphere_fixed[n];
                 outstrstream << "," << fixed;
             }
 
-            if (GET_OUTPUT_SETTING(GROUP)) {
+            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::GROUP)) {
                 int group = (int)sphere_group[n];
                 outstrstream << "," << group;
             }
 
-            if (GET_OUTPUT_SETTING(CLUSTER)) {
-                int group = (int)sphere_cluster[n];
+            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::CLUSTER)) {
+                int cluster = (int)sphere_cluster[n];
                 outstrstream << "," << cluster;
             }
 
             if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS &&
-                GET_OUTPUT_SETTING(ANG_VEL_COMPONENTS)) {
+                GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS)) {
                 float avx_UU = sphere_Omega_X.at(n) / TIME_SU2UU;
                 float avy_UU = sphere_Omega_Y.at(n) / TIME_SU2UU;
                 float avz_UU = sphere_Omega_Z.at(n) / TIME_SU2UU;
@@ -360,7 +360,7 @@ void ChSystemGpu_impl::WriteFile(
                              << "," << angular_velocity.z();
             }
 
-            if (GET_OUTPUT_SETTING(FORCE_COMPONENTS)) {
+            if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FORCE_COMPONENTS)) {
                 double fx =
                     (sphere_acc_X.at(n) - gran_params->gravAcc_X_SU) * gran_params->sphere_mass_SU * FORCE_SU2UU;
                 double fy =
@@ -437,7 +437,7 @@ void ChSystemGpu_impl::WriteFile(
             delete[] vx, vy, vz;
         }
 
-        if (GET_OUTPUT_SETTING(ABSV)) {
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ABSV)) {
             float* absv = new float[nSpheres];
             for (size_t n = 0; n < nSpheres; n++) {
                 absv[n] = sqrt(pos_X_dt.at(n) * pos_X_dt.at(n) + pos_Y_dt.at(n) * pos_Y_dt.at(n) +
@@ -450,7 +450,7 @@ void ChSystemGpu_impl::WriteFile(
             delete[] absv;
         }
 
-        if (GET_OUTPUT_SETTING(FIXITY)) {
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::FIXITY)) {
             unsigned char* fixed = new unsigned char[nSpheres];
             for (size_t n = 0; n < nSpheres; n++) {
                 fixed[n] = (unsigned char)sphere_fixed[n];
@@ -461,7 +461,7 @@ void ChSystemGpu_impl::WriteFile(
             delete[] fixed;
         }
 
-        if (GET_OUTPUT_SETTING(GROUP)) {
+        if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::GROUP)) {
             unsigned char* group = new unsigned char[nSpheres];
             for (size_t n = 0; n < nSpheres; n++) {
                 group[n] = sphere_group[n];

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -132,6 +132,7 @@ size_t ChSystemGpu_impl::EstimateMemUsage() const {
 
 void ChSystemGpu_impl::packSphereDataPointers() {
     // Set data from system
+    printf("packSphereDataPointers\n");
     sphere_data->sphere_local_pos_X = sphere_local_pos_X.data();
     sphere_data->sphere_local_pos_Y = sphere_local_pos_Y.data();
     sphere_data->sphere_local_pos_Z = sphere_local_pos_Z.data();
@@ -202,6 +203,7 @@ void ChSystemGpu_impl::packSphereDataPointers() {
             sphere_data->rolling_friction_torque = rolling_friction_torque.data();
         }
     }
+    printf("OUT OF packSphereDataPointers\n");
 }
 
 void ChSystemGpu_impl::WriteFile(

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -191,7 +191,7 @@ void ChSystemGpu_impl::packSphereDataPointers() {
     if ((gran_params->cluster_graph_method > CLUSTER_GRAPH_METHOD::NONE) &&
             (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
         sphere_data->adj_num = adj_num.data();
-        sphere_data->adj_start = adj_start.data();
+        sphere_data->adj_offset = adj_offset.data();
         sphere_data->adj_list = adj_list.data();
     }
 
@@ -519,16 +519,16 @@ void ChSystemGpu_impl::WriteAdjacencyFiles(std::string ofile) const {
     } else {
         std::ofstream ptFilenum(ofile + "_adj_num_start.csv", std::ios::out);
         std::ostringstream adj_num_strstream;
-        adj_num_strstream << "adj_num, adj_start \n";
+        adj_num_strstream << "adj_num, adj_offset \n";
         for (unsigned int n = 0; n < nSpheres; n++) {
             adj_num_strstream
                 << sphere_data->adj_num[n] << ", "
-                << sphere_data->adj_start[n] << "\n";
+                << sphere_data->adj_offset[n] << "\n";
         }
         ptFilenum << adj_num_strstream.str();
 
         std::ostringstream adj_list_strstream;
-        unsigned int adj_list_len = sphere_data->adj_num[nSpheres - 1] + sphere_data->adj_start[nSpheres - 1];
+        unsigned int adj_list_len = sphere_data->adj_num[nSpheres - 1] + sphere_data->adj_offset[nSpheres - 1];
         std::ofstream ptFilelist(ofile + "_adj_list.csv", std::ios::out);
         for (unsigned int m = 0; m < adj_list_len; m++) {
             adj_list_strstream

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -281,6 +281,9 @@ void ChSystemGpu_impl::WriteFile(
         if (GET_OUTPUT_SETTING(GROUP)) {
             outstrstream << ",group";
         }
+        if (GET_OUTPUT_SETTING(CLUSTER)) {
+            outstrstream << ",cluster";
+        }
 
         if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS && GET_OUTPUT_SETTING(ANG_VEL_COMPONENTS)) {
             outstrstream << ",wx,wy,wz";
@@ -337,6 +340,11 @@ void ChSystemGpu_impl::WriteFile(
             if (GET_OUTPUT_SETTING(GROUP)) {
                 int group = (int)sphere_group[n];
                 outstrstream << "," << group;
+            }
+
+            if (GET_OUTPUT_SETTING(CLUSTER)) {
+                int group = (int)sphere_cluster[n];
+                outstrstream << "," << cluster;
             }
 
             if (gran_params->friction_mode != CHGPU_FRICTION_MODE::FRICTIONLESS &&

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -74,6 +74,10 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
     gran_params->friction_mode = CHGPU_FRICTION_MODE::FRICTIONLESS;
     gran_params->rolling_mode = CHGPU_ROLLING_MODE::NO_RESISTANCE;
     gran_params->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
+
+    gran_params->cluster_graph_method = CLUSTER_GRAPH_METHOD::CONTACT;
+    gran_params->cluster_search_method = CLUSTER_GRAPH_METHOD::BFS;
+
     this->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
     this->output_flags = ABSV | ANG_VEL_COMPONENTS;
 
@@ -177,6 +181,13 @@ void ChSystemGpu_impl::packSphereDataPointers() {
 
     if (gran_params->friction_mode == CHGPU_FRICTION_MODE::MULTI_STEP) {
         sphere_data->contact_history_map = contact_history_map.data();
+    }
+
+    if ((gran_params->cluster_graph_method > CLUSTER_GRAPH_METHOD::NONE) &&
+            (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
+        sphere_data->adj_num = adj_num.data();
+        sphere_data->adj_start = adj_start.data();
+        sphere_data->adj_list = adj_list.data();
     }
 
     if (gran_params->recording_contactInfo == true) {

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -79,7 +79,7 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
     gran_params->cluster_search_method = CLUSTER_SEARCH_METHOD::BFS;
 
     gran_params->gdbscan_radius = 0.1f; // [m] ?
-    gran_params->gdbscan_min_pts = 6;
+    gran_params->gdbscan_min_pts = 3;
 
     this->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
     this->output_flags = CHGPU_OUTPUT_FLAGS::ABSV |  CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -78,6 +78,9 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
     gran_params->cluster_graph_method = CLUSTER_GRAPH_METHOD::CONTACT;
     gran_params->cluster_search_method = CLUSTER_SEARCH_METHOD::BFS;
 
+    gran_params->gdbscan_radius = 0.1f; // [m] ?
+    gran_params->gdbscan_min_pts = 6;
+
     this->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
     this->output_flags = CHGPU_OUTPUT_FLAGS::ABSV |  CHGPU_OUTPUT_FLAGS::ANG_VEL_COMPONENTS;
 
@@ -168,6 +171,7 @@ void ChSystemGpu_impl::packSphereDataPointers() {
     sphere_data->sphere_fixed = sphere_fixed.data();
     sphere_data->sphere_group = sphere_group.data();
     sphere_data->sphere_cluster = sphere_cluster.data();
+    sphere_data->sphere_inside_mesh = sphere_inside_mesh.data();
 
     sphere_data->SD_NumSpheresTouching = SD_NumSpheresTouching.data();
     sphere_data->SD_SphereCompositeOffsets = SD_SphereCompositeOffsets.data();
@@ -349,6 +353,7 @@ void ChSystemGpu_impl::WriteFile(
                 int cluster = (int)sphere_cluster[n];
                 outstrstream << "," << cluster;
             }
+
             if (GET_OUTPUT_SETTING(CHGPU_OUTPUT_FLAGS::ADJACENCY)) {
                 int adjacency = (int)adj_num[n];
                 outstrstream << "," << adjacency;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -167,6 +167,7 @@ void ChSystemGpu_impl::packSphereDataPointers() {
 
     sphere_data->sphere_fixed = sphere_fixed.data();
     sphere_data->sphere_group = sphere_group.data();
+    sphere_data->sphere_cluster = sphere_cluster.data();
 
     sphere_data->SD_NumSpheresTouching = SD_NumSpheresTouching.data();
     sphere_data->SD_SphereCompositeOffsets = SD_SphereCompositeOffsets.data();

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -503,6 +503,32 @@ void ChSystemGpu_impl::WriteFile(
     }
 }
 
+void ChSystemGpu_impl::WriteAdjacencyFiles(std::string ofile) const {
+    if (gran_params->cluster_graph_method == CLUSTER_GRAPH_METHOD::NONE) {
+        printf("ERROR: no cluster search method set, no adjacency!\n");
+        exit(1);
+    } else {
+        std::ofstream ptFilenum(ofile + "_adj_num_start.csv", std::ios::out);
+        std::ostringstream adj_num_strstream;
+        adj_num_strstream << "adj_num, adj_start \n";
+        for (unsigned int n = 0; n < nSpheres; n++) {
+            adj_num_strstream
+                << sphere_data->adj_num[n] << ", "
+                << sphere_data->adj_start[n] << "\n";
+        }
+        ptFilenum << adj_num_strstream.str();
+
+        std::ostringstream adj_list_strstream;
+        unsigned int adj_list_len = sphere_data->adj_num[nSpheres - 1] + sphere_data->adj_start[nSpheres - 1];
+        std::ofstream ptFilelist(ofile + "_adj_list.csv", std::ios::out);
+        for (unsigned int m = 0; m < adj_list_len; m++) {
+            adj_list_strstream
+                << sphere_data->adj_list[m] << "\n";
+        }
+        ptFilelist << adj_list_strstream.str();
+    }
+}
+
 void ChSystemGpu_impl::WriteContactInfoFile(std::string ofile) const {
     if (gran_params->recording_contactInfo == false) {
         printf("ERROR: recording_contactInfo set to false!\n");

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -227,6 +227,7 @@ class ChSystemGpu_impl {
         unsigned int* adj_num; // [mySphereID] -> number of adj
         unsigned int* adj_start; // [mySphereID] -> start of adjs in adj_list
         unsigned int* adj_list; // [start + N] -> Nth adj SphereID (n < adj_num[myShpereID])
+        unsigned int contact_total;
     };
 
     // The system is not default-constructible

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -206,6 +206,7 @@ class ChSystemGpu_impl {
         not_stupid_bool* sphere_fixed;  ///< Flags indicating whether or not a sphere is fixed
 
         SPHERE_GROUP* sphere_group;  ///< Group to which the sphere belongs
+        unsigned int* sphere_cluster; ///< Cluster to which the sphere belongs
 
         unsigned int* contact_partners_map;   ///< Contact partners for each sphere. Only in frictional simulations
         not_stupid_bool* contact_active_map;  ///< Whether the frictional contact at an index is active
@@ -543,6 +544,8 @@ class ChSystemGpu_impl {
 
     /// Sphere group
     std::vector<SPHERE_GROUP, cudallocator<SPHERE_GROUP>> sphere_group;
+    /// Sphere cluster
+    std::vector<unsigned int, cudallocator<unsigned int>> sphere_cluster;
 
     /// Set of contact partners for each sphere. Only used in frictional simulations
     std::vector<unsigned int, cudallocator<unsigned int>> contact_partners_map;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -432,6 +432,9 @@ class ChSystemGpu_impl {
     /// Write contact info file
     void WriteContactInfoFile(std::string ofile) const;
 
+    /// Write adjacency info file
+    void WriteAdjacencyFiles(std::string ofile) const;
+
     /// Rough estimate of the total amount of memory used by the system.
     size_t EstimateMemUsage() const;
 

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -93,6 +93,7 @@ class ChSystemGpu_impl {
   protected:
     /// Structure with simulation parameters for sphere-based granular dynamics.
     /// This structure is stored in CUDA unified memory so that it can be accessed from both host and device.
+
     struct GranParams {
         float stepSize_SU;  ///< Timestep in SU
 
@@ -170,6 +171,13 @@ class ChSystemGpu_impl {
         float max_safe_vel = (float)UINT_MAX;
 
         bool recording_contactInfo;  ///< recording contact info
+
+        // GDBSCAN clustering parameters.
+        float gdbscan_radius; // ignored if CLUSTER_GRAPH_METHOD::CONTACT
+        unsigned int gdbscan_min_pts; // used if CLUSTER_GRAPH_METHOD::CONTACT
+
+        // k Nearest Neighbor parameters.
+        unsigned int kNN_neighbors_num;
     };
 
     /// Structure of pointers to kinematic quantities of the ChSystemGpu_impl.
@@ -207,6 +215,7 @@ class ChSystemGpu_impl {
 
         SPHERE_GROUP* sphere_group;  ///< Group to which the sphere belongs
         unsigned int* sphere_cluster; ///< Cluster to which the sphere belongs
+        bool* sphere_inside_mesh; ///< Is the sphere inside the bucket
 
         unsigned int* contact_partners_map;   ///< Contact partners for each sphere. Only in frictional simulations
         not_stupid_bool* contact_active_map;  ///< Whether the frictional contact at an index is active
@@ -548,6 +557,8 @@ class ChSystemGpu_impl {
     std::vector<SPHERE_GROUP, cudallocator<SPHERE_GROUP>> sphere_group;
     /// Sphere cluster
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_cluster;
+    /// Sphere cluster
+    std::vector<bool, cudallocator<bool>> sphere_inside_mesh;
     
     /// Set of contact partners for each sphere. Only used in frictional simulations
     std::vector<unsigned int, cudallocator<unsigned int>> contact_partners_map;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -169,6 +169,14 @@ class ChSystemGpu_impl {
         bool recording_contactInfo;  ///< recording contact info
     };
 
+    /// Graph representation of sphere connectivity
+    /// used to differentiate clusters of particles
+    struct ConnectivityGraph {
+        unsigned int * vertex_adjacency_number;
+        unsigned int * vertex_adjacency_start;
+        unsigned int * adjacency_list;
+
+    }
     /// Structure of pointers to kinematic quantities of the ChSystemGpu_impl.
     /// These pointers must be in device-accessible memory.
     struct SphereData {
@@ -454,6 +462,9 @@ class ChSystemGpu_impl {
 
     /// Holds system degrees of freedom
     SphereData* sphere_data;
+
+    /// Holds system degrees of freedom
+    ConnectivityGraph * con_graph;
 
     /// Contains information about the status of the granular simulator (solver)
     ChSolverStateData stateOfSolver_resources;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -213,7 +213,7 @@ class ChSystemGpu_impl {
 
         not_stupid_bool* sphere_fixed;  ///< Flags indicating whether or not a sphere is fixed
 
-        SPHERE_GROUP* sphere_group;  ///< Group to which the sphere belongs
+        SPHERE_TYPE* sphere_type;  ///< Group to which the sphere belongs
         unsigned int* sphere_cluster; ///< Cluster to which the sphere belongs
         not_stupid_bool* sphere_inside_mesh; ///< Is the sphere inside the volume
 
@@ -551,7 +551,7 @@ class ChSystemGpu_impl {
     std::vector<not_stupid_bool, cudallocator<not_stupid_bool>> sphere_fixed;
 
     /// Sphere group
-    std::vector<SPHERE_GROUP, cudallocator<SPHERE_GROUP>> sphere_group;
+    std::vector<SPHERE_TYPE, cudallocator<SPHERE_TYPE>> sphere_type;
     /// Sphere cluster
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_cluster;
     /// Sphere inside mesh

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -235,7 +235,7 @@ class ChSystemGpu_impl {
         /// Graph representation of sphere connectivity
         /// used to differentiate clusters of particles
         unsigned int* adj_num; // [mySphereID] -> number of adj
-        unsigned int* adj_start; // [mySphereID] -> start of adjs in adj_list
+        unsigned int* adj_offset; // [mySphereID] -> start of adjs in adj_list
         unsigned int* adj_list; // [start + N] -> Nth adj SphereID (n < adj_num[myShpereID])
     };
 
@@ -591,7 +591,7 @@ class ChSystemGpu_impl {
 
     // Adjacency lists for clustering
     std::vector<unsigned int, cudallocator<unsigned int>> adj_num;
-    std::vector<unsigned int, cudallocator<unsigned int>> adj_start;
+    std::vector<unsigned int, cudallocator<unsigned int>> adj_offset;
     std::vector<unsigned int, cudallocator<unsigned int>> adj_list;
 
     /// User provided timestep in UU

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -215,7 +215,7 @@ class ChSystemGpu_impl {
 
         SPHERE_GROUP* sphere_group;  ///< Group to which the sphere belongs
         unsigned int* sphere_cluster; ///< Cluster to which the sphere belongs
-        bool* sphere_inside_mesh; ///< Is the sphere inside the bucket
+        not_stupid_bool* sphere_inside_mesh; ///< Is the sphere inside the bucket
 
         unsigned int* contact_partners_map;   ///< Contact partners for each sphere. Only in frictional simulations
         not_stupid_bool* contact_active_map;  ///< Whether the frictional contact at an index is active
@@ -557,8 +557,8 @@ class ChSystemGpu_impl {
     std::vector<SPHERE_GROUP, cudallocator<SPHERE_GROUP>> sphere_group;
     /// Sphere cluster
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_cluster;
-    /// Sphere cluster
-    std::vector<bool, cudallocator<bool>> sphere_inside_mesh;
+    /// Sphere inside mesh
+    std::vector<not_stupid_bool, cudallocator<not_stupid_bool>> sphere_inside_mesh;
     
     /// Set of contact partners for each sphere. Only used in frictional simulations
     std::vector<unsigned int, cudallocator<unsigned int>> contact_partners_map;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -213,7 +213,7 @@ class ChSystemGpu_impl {
 
         not_stupid_bool* sphere_fixed;  ///< Flags indicating whether or not a sphere is fixed
 
-        SPHERE_TYPE* sphere_type;  ///< Group to which the sphere belongs
+        SPHERE_TYPE* sphere_type;  ///< Type of sphere
         unsigned int* sphere_cluster; ///< Cluster to which the sphere belongs
         not_stupid_bool* sphere_inside_mesh; ///< Is the sphere inside the volume
 
@@ -550,7 +550,7 @@ class ChSystemGpu_impl {
     /// Fixity of each sphere
     std::vector<not_stupid_bool, cudallocator<not_stupid_bool>> sphere_fixed;
 
-    /// Sphere group
+    /// Sphere type
     std::vector<SPHERE_TYPE, cudallocator<SPHERE_TYPE>> sphere_type;
     /// Sphere cluster
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_cluster;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -362,9 +362,6 @@ class ChSystemGpu_impl {
     /// Get map of the max z positions of the spheres
     std::vector<float3> get_max_z_map(unsigned int x_size, unsigned int y_size) const;
 
-    /// Reset ground group
-    void reset_ground_group();
-
     /// Advance simulation by duration in user units, return actual duration elapsed
     /// Requires initialize() to have been called
     virtual double AdvanceSimulation(float duration);

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -228,7 +228,6 @@ class ChSystemGpu_impl {
         unsigned int* adj_num; // [mySphereID] -> number of adj
         unsigned int* adj_start; // [mySphereID] -> start of adjs in adj_list
         unsigned int* adj_list; // [start + N] -> Nth adj SphereID (n < adj_num[myShpereID])
-        unsigned int contact_total;
     };
 
     // The system is not default-constructible
@@ -546,7 +545,7 @@ class ChSystemGpu_impl {
     std::vector<SPHERE_GROUP, cudallocator<SPHERE_GROUP>> sphere_group;
     /// Sphere cluster
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_cluster;
-
+    
     /// Set of contact partners for each sphere. Only used in frictional simulations
     std::vector<unsigned int, cudallocator<unsigned int>> contact_partners_map;
     /// Whether the frictional contact at an index is active

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -175,9 +175,6 @@ class ChSystemGpu_impl {
         // GDBSCAN clustering parameters.
         float gdbscan_radius; // ignored if CLUSTER_GRAPH_METHOD::CONTACT
         unsigned int gdbscan_min_pts; // used if CLUSTER_GRAPH_METHOD::CONTACT
-
-        // k Nearest Neighbor parameters.
-        unsigned int kNN_neighbors_num;
     };
 
     /// Structure of pointers to kinematic quantities of the ChSystemGpu_impl.

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -99,7 +99,6 @@ class ChSystemGpu_impl {
         CHGPU_FRICTION_MODE friction_mode;      ///< Which friction mode is active for the simulation
         CHGPU_ROLLING_MODE rolling_mode;        ///< Which rolling resistance model is active
         CHGPU_TIME_INTEGRATOR time_integrator;  ///< Which time integrator is active
-
         
         CLUSTER_GRAPH_METHOD cluster_graph_method; /// graph construction for clustering
         CLUSTER_SEARCH_METHOD cluster_search_method; /// search algorithm used for clustering
@@ -575,6 +574,11 @@ class ChSystemGpu_impl {
 
     /// List of owner subdomains for each sphere
     std::vector<unsigned int, cudallocator<unsigned int>> sphere_owner_SDs;
+
+    // Adjacency lists for clustering
+    std::vector<unsigned int, cudallocator<unsigned int>> adj_num;
+    std::vector<unsigned int, cudallocator<unsigned int>> adj_start;
+    std::vector<unsigned int, cudallocator<unsigned int>> adj_list;
 
     /// User provided timestep in UU
     float stepSize_UU;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -100,6 +100,10 @@ class ChSystemGpu_impl {
         CHGPU_ROLLING_MODE rolling_mode;        ///< Which rolling resistance model is active
         CHGPU_TIME_INTEGRATOR time_integrator;  ///< Which time integrator is active
 
+        
+        CLUSTER_GRAPH_METHOD cluster_graph_method; /// graph construction for clustering
+        CLUSTER_SEARCH_METHOD cluster_search_method; /// search algorithm used for clustering
+
         /// Ratio of normal force to peak tangent force, also arctan(theta) where theta is the friction angle
         /// sphere-to-sphere
         float static_friction_coeff_s2s;
@@ -169,14 +173,6 @@ class ChSystemGpu_impl {
         bool recording_contactInfo;  ///< recording contact info
     };
 
-    /// Graph representation of sphere connectivity
-    /// used to differentiate clusters of particles
-    struct ConnectivityGraph {
-        unsigned int * vertex_adjacency_number;
-        unsigned int * vertex_adjacency_start;
-        unsigned int * adjacency_list;
-
-    }
     /// Structure of pointers to kinematic quantities of the ChSystemGpu_impl.
     /// These pointers must be in device-accessible memory.
     struct SphereData {
@@ -226,6 +222,12 @@ class ChSystemGpu_impl {
         unsigned int* spheres_in_SD_composite;       ///< Big composite array of sphere-subdomain membership
 
         unsigned int* sphere_owner_SDs;  ///< List of owner subdomains for each sphere
+
+        /// Graph representation of sphere connectivity
+        /// used to differentiate clusters of particles
+        unsigned int* adj_num; // [mySphereID] -> number of adj
+        unsigned int* adj_start; // [mySphereID] -> start of adjs in adj_list
+        unsigned int* adj_list; // [start + N] -> Nth adj SphereID (n < adj_num[myShpereID])
     };
 
     // The system is not default-constructible
@@ -462,9 +464,6 @@ class ChSystemGpu_impl {
 
     /// Holds system degrees of freedom
     SphereData* sphere_data;
-
-    /// Holds system degrees of freedom
-    ConnectivityGraph * con_graph;
 
     /// Contains information about the status of the granular simulator (solver)
     ChSolverStateData stateOfSolver_resources;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -215,7 +215,7 @@ class ChSystemGpu_impl {
 
         SPHERE_GROUP* sphere_group;  ///< Group to which the sphere belongs
         unsigned int* sphere_cluster; ///< Cluster to which the sphere belongs
-        not_stupid_bool* sphere_inside_mesh; ///< Is the sphere inside the bucket
+        not_stupid_bool* sphere_inside_mesh; ///< Is the sphere inside the volume
 
         unsigned int* contact_partners_map;   ///< Contact partners for each sphere. Only in frictional simulations
         not_stupid_bool* contact_active_map;  ///< Whether the frictional contact at an index is active


### PR DESCRIPTION
Implements a graph-based clustering algorithm based in part on the G-DBSCAN method on CUDA.

The particle-particle contacts computed by Chrono in `contact_active_map` are leveraged to produce a connectivity graph. This graph is represented as a compact adjacency list which are 3 simple arrays in memory. Then, a search algorithm is applied on the graph to identify the clusters.

If need ever arises, the graph can be constructed with other connectivity criteria, such as point-point distance as in density-based approached. Although, this would require the creation of more function and function kernels.

Similarly, the currently implement Breadth-First search (BFS) can be switched out for faster algorithms if need be.