### PR TITLE
Implement Lowest method to find Ground cluster as #8

### DIFF
--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -66,7 +66,7 @@ enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement faster
 
 enum class CLUSTER_GROUND_METHOD {NONE = 0, BIGGEST = 1, LOWEST = 2};
 /// BIGGEST: cluster with the most number of spheres is GROUND
-/// LOWEST: cluster with many particles close to the bounding box bottom
+/// LOWEST: clusters with any particle below a z-plane are GROUND
 
 /// Cluster index.
 /// NOISE spheres are part of the INVALID cluster (not really a cluster)

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -70,9 +70,8 @@ enum class CLUSTER_GROUND_METHOD {NONE = 0, BIGGEST = 1, LOWEST = 2};
 
 /// Cluster index.
 /// NOISE spheres are part of the INVALID cluster (not really a cluster)
-/// Any cluster that contain a VOLUME sphere is part VOLUME cluster, EXCEPT 
-/// EXCEPT if it is the GROUND cluster
-/// Otherwise cluster index increases from START when cluster found 
+/// Any cluster that contain a VOLUME sphere is the VOLUME, EXCEPT the GROUND
+/// Otherwise cluster index increases from START when clusters found 
 /// no sphere with NONE if no bugs.
 enum class CLUSTER_INDEX {NONE = 0, GROUND = 1, INVALID = 2, VOLUME = 3, START = 4}; /* number of clusters go up to nSpheres */
 

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -53,19 +53,20 @@ enum CHGPU_OUTPUT_FLAGS { ABSV = 1 << 0, VEL_COMPONENTS = 1 << 1,
                           CLUSTER = 1 << 6, ADJACENCY = 1 << 7 };
 
 /// Clustering algorithm switches
-// 0 on CLUSTER_GRAPH_METHOD or CLUSTER_SEARCH_METHO switch means no clustering
-//  all sphere_type and sphere_cluster to 0.
+/// 0 is reserved for NONE
+/// 0 on CLUSTER_GRAPH_METHOD or CLUSTER_SEARCH_METHOD switch means no clustering
+/// 0 on CLUSTER_GROUND_METHOD means GROUND cluster not tagged
+
 enum class CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1, PROXIMITY = 2}; /* TODO: Implement proximity graph construction */
-// CONTACT leverages sphere_contact_map to build the graph.
-// PROXIMITY determine contacts by checking if distance between sphere pairs < gbscan_radius; TODO UNTESTED
+/// CONTACT leverages sphere_contact_map to build the graph.
+/// PROXIMITY determine contacts by checking if distance between sphere pairs < gbscan_radius; TODO UNTESTED
 
 enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement faster search than BFS
-// BFS -> Breadth-First search
+/// BFS -> Breadth-First search
 
-// How is the ground cluster identified
 enum class CLUSTER_GROUND_METHOD {NONE = 0, BIGGEST = 1, LOWEST = 2};
-// BIGGEST: cluster with the most number of spheres
-// LOWEST: cluster with many particles close to the bounding box bottom
+/// BIGGEST: cluster with the most number of spheres is GROUND
+/// LOWEST: cluster with many particles close to the bounding box bottom
 
 /// Cluster index.
 /// NOISE spheres are part of the INVALID cluster (not really a cluster)

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -53,7 +53,8 @@ enum CHGPU_OUTPUT_FLAGS { ABSV = 1 << 0, VEL_COMPONENTS = 1 << 1,
                           CLUSTER = 1 << 6, ADJACENCY = 1 << 7 };
 
 /// Clustering algorithm switches
-// 0 on ANY cluster related switch means no clustering done, all sphere_type and sphere_cluster to 0.
+// 0 on CLUSTER_GRAPH_METHOD or CLUSTER_SEARCH_METHO switch means no clustering
+//  all sphere_type and sphere_cluster to 0.
 enum class CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1, PROXIMITY = 2}; /* TODO: Implement proximity graph construction */
 // CONTACT leverages sphere_contact_map to build the graph.
 // PROXIMITY determine contacts by checking if distance between sphere pairs < gbscan_radius; TODO UNTESTED
@@ -61,10 +62,15 @@ enum class CLUSTER_GRAPH_METHOD {NONE = 0, CONTACT = 1, PROXIMITY = 2}; /* TODO:
 enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement faster search than BFS
 // BFS -> Breadth-First search
 
-/// Cluster index. Ground cluster has most spheres.
-/// Noise spheres are part of their own invalid cluster,
-/// Any cluster that contain a VOLUME sphere is part 
-/// of the VOLUME cluster, except if it is the GROUND cluster
+// How is the ground cluster identified
+enum class CLUSTER_GROUND_METHOD {BIGGEST = 0, LOWEST = 1}; 
+// BIGGEST: cluster with the most number of spheres
+// LOWEST: cluster with many particles close to the bounding box bottom
+
+/// Cluster index.
+/// NOISE spheres are part of the INVALID cluster,
+/// Any cluster that contain a VOLUME sphere is part VOLUME cluster, EXCEPT 
+/// EXCEPT if it is the GROUND cluster
 /// Otherwise cluster index increases from START when cluster found 
 enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, VOLUME = 2, START = 3}; /* number of clusters go up to nSpheres */
 

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -68,15 +68,15 @@ enum class CLUSTER_GROUND_METHOD {NONE = 0, BIGGEST = 1, LOWEST = 2};
 // LOWEST: cluster with many particles close to the bounding box bottom
 
 /// Cluster index.
-/// NOISE spheres are part of the INVALID cluster,
+/// NOISE spheres are part of the INVALID cluster (not really a cluster)
 /// Any cluster that contain a VOLUME sphere is part VOLUME cluster, EXCEPT 
 /// EXCEPT if it is the GROUND cluster
 /// Otherwise cluster index increases from START when cluster found 
-enum class CLUSTER_INDEX {GROUND = 0, INVALID = 1, VOLUME = 2, START = 3}; /* number of clusters go up to nSpheres */
+enum class CLUSTER_INDEX {NONE = 0, GROUND = 1, INVALID = 2, VOLUME = 3, START = 4}; /* number of clusters go up to nSpheres */
 
 /// Sphere type, CORE BORDER or NOISE for clustering, VOLUME for inside mesh
 /// a sphere can be a CORE or BORDER of any cluster. 
-enum class SPHERE_TYPE {CORE = 0, BORDER = 1, NOISE = 2, VOLUME = 3};
+enum class SPHERE_TYPE {NONE = 0, CORE = 1, BORDER = 2, NOISE = 3, VOLUME = 4};
 
 #define GET_OUTPUT_SETTING(setting) (this->output_flags & static_cast<unsigned int>(setting))
 

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -72,10 +72,12 @@ enum class CLUSTER_GROUND_METHOD {NONE = 0, BIGGEST = 1, LOWEST = 2};
 /// Any cluster that contain a VOLUME sphere is part VOLUME cluster, EXCEPT 
 /// EXCEPT if it is the GROUND cluster
 /// Otherwise cluster index increases from START when cluster found 
+/// no sphere with NONE if no bugs.
 enum class CLUSTER_INDEX {NONE = 0, GROUND = 1, INVALID = 2, VOLUME = 3, START = 4}; /* number of clusters go up to nSpheres */
 
 /// Sphere type, CORE BORDER or NOISE for clustering, VOLUME for inside mesh
 /// a sphere can be a CORE or BORDER of any cluster. 
+/// no sphere with NONE if no bugs.
 enum class SPHERE_TYPE {NONE = 0, CORE = 1, BORDER = 2, NOISE = 3, VOLUME = 4};
 
 #define GET_OUTPUT_SETTING(setting) (this->output_flags & static_cast<unsigned int>(setting))

--- a/src/chrono_gpu/ChGpuDefines.h
+++ b/src/chrono_gpu/ChGpuDefines.h
@@ -63,7 +63,7 @@ enum class CLUSTER_SEARCH_METHOD {NONE = 0, BFS = 1}; // TO DO: implement faster
 // BFS -> Breadth-First search
 
 // How is the ground cluster identified
-enum class CLUSTER_GROUND_METHOD {BIGGEST = 0, LOWEST = 1}; 
+enum class CLUSTER_GROUND_METHOD {NONE = 0, BIGGEST = 1, LOWEST = 2};
 // BIGGEST: cluster with the most number of spheres
 // LOWEST: cluster with many particles close to the bounding box bottom
 

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -305,13 +305,11 @@ __host__ void IdentifyGroundClusterByLowest(
         gpuErrchk(cudaPeekAtLastError());
         gpuErrchk(cudaDeviceSynchronize());
     }
-    
 
 
     gpuErrchk(cudaFree(d_below));
     gpuErrchk(cudaFree(d_below_num));
     free(h_below_num);
-    
 }
 
 __host__ void IdentifyGroundClusterByBiggest(
@@ -320,17 +318,18 @@ __host__ void IdentifyGroundClusterByBiggest(
         unsigned int ** h_clusters,
         unsigned int nSpheres) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
-    unsigned int ground_cluster = 0;
+    unsigned int ground_cluster = static_cast<unsigned int>(chrono::gpu::CLUSTER_INDEX::NONE);
     unsigned int cluster_num = h_clusters[0][0];
     unsigned int sphere_num_in_cluster = 1;
     unsigned int biggest_cluster_size = 1;
-    // find which cluster is the bigged
-    for (size_t i = 1; i < cluster_num; i++) {
+
+    // find which cluster is the biggest
+    for (size_t i = 1; i < (cluster_num + 1); i++) {
         sphere_num_in_cluster = h_clusters[i][0];
         assert(sphere_num_in_cluster <= nSpheres);
         if (sphere_num_in_cluster > biggest_cluster_size) {
             biggest_cluster_size = sphere_num_in_cluster;
-            ground_cluster = i;
+            ground_cluster = i + static_cast<unsigned int>(chrono::gpu::CLUSTER_INDEX::START);
         }
     }
 

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -291,7 +291,7 @@ __host__ void FreeClusters(unsigned int ** h_clusters) {
     free(h_clusters);
 }
 
-/// Finds cluster in h_clusters with most sphres (biggest cluster)
+/// Finds cluster in h_clusters with most spheres (biggest cluster)
 /// sets sphere_cluster of all those spheres to GROUND
 /// OVERWRITES the VOLUME cluster
 __host__ void IdentifyGroundClusterByBiggest(ChSystemGpu_impl::GranSphereDataPtr sphere_data,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -255,13 +255,17 @@ __host__ void ConstructGraphByProximity(ChSystemGpu_impl::GranSphereDataPtr sphe
                                                                    radius);
 }
 
-__host__ void IdentifyGroundClusterByBiggest(
+__host__ void IdentifyGroundClusterByLowest(
         ChSystemGpu_impl::GranSphereDataPtr sphere_data,
         ChSystemGpu_impl::GranParamsPtr gran_params,
         unsigned int ** h_clusters) {
-    
-}
+    unsigned int ground_cluster = 0;
+    ///　PLAN：
+    ///　Find ALL clusters with any sphere center below plane box_z + 1*sphere_radius
+    float z_lim = -box_size_Z / 2 + sphere_radius_UU;
 
+    TagGroundCluster(sphere_data, gran_params, h_clusters, ground_cluster);
+}
 
 __host__ void IdentifyGroundClusterByBiggest(
         ChSystemGpu_impl::GranSphereDataPtr sphere_data,
@@ -280,15 +284,19 @@ __host__ void IdentifyGroundClusterByBiggest(
             ground_cluster = i;
         }
     }
-    // tag all spheres in biggest cluster to GROUND
+    TagGroundCluster(sphere_data, gran_params, h_clusters, ground_cluster);
+}
+
+__host__ void TagGroundCluster(
+        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+        ChSystemGpu_impl::GranParamsPtr gran_params,
+        unsigned int ** h_clusters, unsigned int ground_cluster) {
     sphere_num_in_cluster = h_clusters[ground_cluster][0];
     assert(h_clusters[ground_cluster][0] <= nSpheres);
     for (size_t j = 1; j < (sphere_num_in_cluster + 1); j++) {
         unsigned int CurrentSphereID = h_clusters[ground_cluster][j];
         sphere_data->sphere_cluster[CurrentSphereID] = static_cast<unsigned int>(chrono::gpu::CLUSTER_INDEX::GROUND);
     }
-    gpuErrchk(cudaPeekAtLastError());
-    gpuErrchk(cudaDeviceSynchronize());
 }
 
 /// G-DBSCAN; density-based h_clustering algorithm.

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -350,18 +350,6 @@ __host__ void IdentifyGroundClusterByBiggest(
     gpuErrchk(cudaDeviceSynchronize());
 }
 
-__host__ void TagGroundCluster(
-        ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-        ChSystemGpu_impl::GranParamsPtr gran_params,
-        unsigned int ** h_clusters, unsigned int ground_cluster) {
-    sphere_num_in_cluster = h_clusters[ground_cluster][0];
-    assert(h_clusters[ground_cluster][0] <= nSpheres);
-    for (size_t j = 1; j < (sphere_num_in_cluster + 1); j++) {
-        unsigned int CurrentSphereID = h_clusters[ground_cluster][j];
-        sphere_data->sphere_cluster[CurrentSphereID] = static_cast<unsigned int>(chrono::gpu::CLUSTER_INDEX::GROUND);
-    }
-}
-
 /// G-DBSCAN; density-based h_clustering algorithm.
 /// Identifies core, border and noise points in h_clusters.
 /// Searches using a parallel Breadth-First search

--- a/src/chrono_gpu/cuda/ChGpuClustering.cu
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cu
@@ -23,6 +23,9 @@
 #include "chrono_gpu/cuda/ChGpu_SMC.cuh"
 #include "chrono_gpu/cuda/ChGpuClustering.cuh"
 
+namespace chrono {
+namespace gpu {
+
 /// Identifies all clusters by breadth first search and outputs
 /// Returns h_clusters: array of pointers to arrays of variable length
 /// h_clusters[0][0] -> number of pointers/cluster in h_clusters
@@ -366,9 +369,9 @@ __host__ void IdentifyVolumeCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_d
 
         // find if any sphere in cluster was tagged in the VOLUME type
         FindVolumeTypeInCluster<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(sphere_data,
-                                                               nSpheres,
-                                                               d_in_volume,
-                                                               cluster_index);
+                                                                     nSpheres,
+                                                                     d_in_volume,
+                                                                     cluster_index);
         gpuErrchk(cudaPeekAtLastError());
         gpuErrchk(cudaDeviceSynchronize());
 
@@ -440,9 +443,9 @@ __host__ void IdentifyGroundCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_d
 /// Searches using a parallel Breadth-First search
 /// min_pts: minimal number of points for a cluster
 __host__ unsigned int ** GdbscanSearchGraphByBFS(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                 ChSystemGpu_impl::GranParamsPtr gran_params,
-                                 unsigned int nSpheres,
-                                 size_t min_pts) {
+                                                 ChSystemGpu_impl::GranParamsPtr gran_params,
+                                                 unsigned int nSpheres,
+                                                 size_t min_pts) {
     unsigned int nBlocks = (nSpheres + CUDA_THREADS_PER_BLOCK - 1) / CUDA_THREADS_PER_BLOCK;
 
     /// sphere_type is CORE if neighbors_num > min_pts else NOISE
@@ -467,4 +470,5 @@ __host__ unsigned int ** GdbscanSearchGraphByBFS(ChSystemGpu_impl::GranSphereDat
     return(h_clusters);
 }
 
-
+}
+}

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -143,9 +143,7 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
     }
 }
 
-// Find if any particle is in the volume cluster.
-// If any sphere in cluster sphere_type == VOLUME -> sphere_cluster = VOLUME
-// UNLESS it is the biggest cluster -> sphere_cluster = GROUND
+// Find if any particle in the cluster has type VOLUME
 static __global__ void FindVolumeTypeInCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                                unsigned int nSpheres,
                                                bool * in_volume,
@@ -164,8 +162,8 @@ static __global__ void FindVolumeTypeInCluster(ChSystemGpu_impl::GranSphereDataP
 /// needs fully known adj_num
 /// call BEFORE ComputeAdjList___
 static __host__ void ComputeAdjOffsetFromAdjNum(unsigned int nSpheres,
-                                               unsigned int * adj_num,
-                                               unsigned int * adj_offset) {
+                                                unsigned int * adj_num,
+                                                unsigned int * adj_offset) {
     memcpy(adj_offset, adj_num, sizeof(*adj_offset) * nSpheres);
     /// all start indices AFTER mySphereID depend on it -> exclusive sum
     void * d_temp_storage = NULL;

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -136,6 +136,7 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
         mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(ownerSD, mySphere_pos_local, gran_params));
 
         if (sphere_data->sphere_cluster[mySphereID] == cluster) {
+            // printf("mySphere_pos_global %f %f \n", mySphere_pos_global.z * gran_params->LENGTH_UNIT, z_lim);
             if (static_cast<float>(mySphere_pos_global.z * gran_params->LENGTH_UNIT) < z_lim) {
                 d_below[mySphereID] = true;
             }

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -112,7 +112,7 @@ static __global__ void SwitchClusterIndex(ChSystemGpu_impl::GranSphereDataPtr sp
 
 
 // Find if any particle in the cluster are below a certain z_lim
-// if input param cluster == 0/NONE checks all spheres.
+// if input param cluster == NONE checks all spheres.
 static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
                                            unsigned int nSpheres,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -119,7 +119,8 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
                                            unsigned int nSpheres,
                                            bool * d_below,
                                            unsigned int cluster,
-                                           float z_lim) {
+                                           float z_lim, 
+                                           double LENGTH_SU2UU) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     unsigned int thisSD = blockIdx.x;
 
@@ -139,8 +140,7 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
         ///    cond 2-  sphere is in input cluster     -> check sphere
         if ((cluster == static_cast<unsigned int>(CLUSTER_INDEX::NONE)) ||
             (sphere_data->sphere_cluster[mySphereID] == cluster)) {
-            if (mySphere_pos_global.z < z_lim) {
-                printf("%f %f \n", mySphere_pos_global.z, z_lim);
+            if ((mySphere_pos_global.z * LENGTH_SU2UU) < z_lim) {
                 d_below[mySphereID] = true;
             }
         }
@@ -366,9 +366,17 @@ __host__ void ConstructGraphByProximity(ChSystemGpu_impl::GranSphereDataPtr sphe
                                         size_t min_pts,
                                         float radius);
 
-__host__ void GdbscanSearchGraphByBFS(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+__host__ unsigned int ** GdbscanSearchGraphByBFS(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                       ChSystemGpu_impl::GranParamsPtr gran_params,
                                       unsigned int nSpheres,
                                       size_t min_pts);
+
+__host__ void IdentifyGroundCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                    ChSystemGpu_impl::GranParamsPtr gran_params,
+                                    unsigned int nSpheres,
+                                    unsigned int ** h_clusters, 
+                                    double LENGTH_SU2UU);
+
+__host__ void FreeClusters(unsigned int ** h_clusters);
 
 /// @} gpu_cuda

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -147,14 +147,15 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
 // Find if any particle is in the volume cluster.
 // If any sphere in cluster sphere_type == VOLUME -> sphere_cluster = VOLUME
 // UNLESS it is the biggestbiggest cluster -> sphere_cluster = GROUND
-static __global__ void FindVolumeCluster(unsigned int nSpheres,
-                                         bool * visited,
+static __global__ void FindVolumeTypeInCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                         unsigned int nSpheres,
                                          bool * in_volume,
-                                         SPHERE_TYPE* sphere_type) {
+                                         unsigned int cluster) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
-        if ((sphere_type[mySphereID] == SPHERE_TYPE::VOLUME) && (visited[mySphereID])) {
+        if ((sphere_data->sphere_type[mySphereID] == SPHERE_TYPE::VOLUME) &&
+            (sphere_data->sphere_cluster[mySphereID] == cluster)){
             in_volume[mySphereID] = true;
         }
     }
@@ -368,6 +369,11 @@ __host__ unsigned int ** GdbscanSearchGraphByBFS(ChSystemGpu_impl::GranSphereDat
                                       size_t min_pts);
 
 __host__ void IdentifyGroundCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                    ChSystemGpu_impl::GranParamsPtr gran_params,
+                                    unsigned int nSpheres,
+                                    unsigned int ** h_clusters);
+
+__host__ void IdentifyVolumeCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                     ChSystemGpu_impl::GranParamsPtr gran_params,
                                     unsigned int nSpheres,
                                     unsigned int ** h_clusters);

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -122,7 +122,6 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
                                            unsigned int cluster,
                                            float z_lim) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
-    unsigned int thisSD = blockIdx.x;
 
     // don't overrun the array
     if (mySphereID < nSpheres) {
@@ -135,8 +134,8 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
                                        sphere_data->sphere_local_pos_Z[mySphereID]);
         mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(ownerSD, mySphere_pos_local, gran_params));
 
-        if (sphere_data->sphere_cluster[mySphereID] == cluster) {
-            // printf("mySphere_pos_global %f %f \n", mySphere_pos_global.z * gran_params->LENGTH_UNIT, z_lim);
+        if ((sphere_data->sphere_cluster[mySphereID] == cluster) ||
+            (cluster == static_cast<unsigned int>(chrono::gpu::CLUSTER_INDEX::NONE))) {
             if (static_cast<float>(mySphere_pos_global.z * gran_params->LENGTH_UNIT) < z_lim) {
                 d_below[mySphereID] = true;
             }
@@ -146,11 +145,11 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
 
 // Find if any particle is in the volume cluster.
 // If any sphere in cluster sphere_type == VOLUME -> sphere_cluster = VOLUME
-// UNLESS it is the biggestbiggest cluster -> sphere_cluster = GROUND
+// UNLESS it is the biggest cluster -> sphere_cluster = GROUND
 static __global__ void FindVolumeTypeInCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                         unsigned int nSpheres,
-                                         bool * in_volume,
-                                         unsigned int cluster) {
+                                               unsigned int nSpheres,
+                                               bool * in_volume,
+                                               unsigned int cluster) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
     // don't overrun the array
     if (mySphereID < nSpheres) {
@@ -364,9 +363,9 @@ __host__ void ConstructGraphByProximity(ChSystemGpu_impl::GranSphereDataPtr sphe
                                         float radius);
 
 __host__ unsigned int ** GdbscanSearchGraphByBFS(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                      ChSystemGpu_impl::GranParamsPtr gran_params,
-                                      unsigned int nSpheres,
-                                      size_t min_pts);
+                                                 ChSystemGpu_impl::GranParamsPtr gran_params,
+                                                 unsigned int nSpheres,
+                                                 size_t min_pts);
 
 __host__ void IdentifyGroundCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                     ChSystemGpu_impl::GranParamsPtr gran_params,

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -95,8 +95,8 @@ static __global__ void GdbscanFinalClusterFromType(unsigned int nSpheres,
     }
 }
 
-// Switch cluster index of spheres. 
-// Mostly used to switch index of a certain cluster to CLUSTER_INDEX::GROUND
+/// Switch cluster index of spheres.
+/// Mostly used to switch index of a certain cluster to CLUSTER_INDEX::GROUND
 static __global__ void SwitchClusterIndex(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                           ChSystemGpu_impl::GranParamsPtr gran_params,
                                           unsigned int nSpheres,
@@ -111,8 +111,9 @@ static __global__ void SwitchClusterIndex(ChSystemGpu_impl::GranSphereDataPtr sp
 }
 
 
-// Find if any particle in the cluster are below a certain z_lim
-// if input param cluster == NONE checks all spheres.
+/// Find if any particle in a cluster are below a certain z_lim
+/// if input param cluster == NONE checks all spheres.
+/// VOLUME cluster is set before ground cluster
 static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
                                            unsigned int nSpheres,
@@ -131,6 +132,9 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
                                        sphere_data->sphere_local_pos_Y[mySphereID],
                                        sphere_data->sphere_local_pos_Z[mySphereID]);
         mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));
+        /// if:
+        ///    cond 1-  cluster == NONE                -> check sphere
+        ///    cond 2-  sphere is in input cluster     -> check sphere
         if ((cluster == static_cast<unsigned int>(CLUSTER_INDEX::NONE)) ||
             (sphere_data->sphere_cluster[mySphereID] == cluster)) {
             if (mySphere_pos_global.z < z_lim) {

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -120,6 +120,7 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
                                            unsigned int cluster,
                                            float z_lim) {
     unsigned int mySphereID = threadIdx.x + blockIdx.x * blockDim.x;
+    unsigned int thisSD = blockIdx.x;
 
     // don't overrun the array
     if (mySphereID < nSpheres) {

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -138,6 +138,7 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
         if ((cluster == static_cast<unsigned int>(CLUSTER_INDEX::NONE)) ||
             (sphere_data->sphere_cluster[mySphereID] == cluster)) {
             if (mySphere_pos_global.z < z_lim) {
+                printf("%f %f \n", mySphere_pos_global.z, z_lim);
                 d_below[mySphereID] = true;
             }
         }

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -132,6 +132,8 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
                                        sphere_data->sphere_local_pos_Y[mySphereID],
                                        sphere_data->sphere_local_pos_Z[mySphereID]);
         mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));
+        // THIS POSITION IS WRONG FOR SOME REASON
+
         /// if:
         ///    cond 1-  cluster == NONE                -> check sphere
         ///    cond 2-  sphere is in input cluster     -> check sphere

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -112,7 +112,7 @@ static __global__ void SwitchClusterIndex(ChSystemGpu_impl::GranSphereDataPtr sp
 
 
 // Find if any particle in the cluster are below a certain z_lim
-// if input param cluster == 0 checks all spheres.
+// if input param cluster == 0/NONE checks all spheres.
 static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                            ChSystemGpu_impl::GranParamsPtr gran_params,
                                            unsigned int nSpheres,
@@ -130,7 +130,8 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
                                        sphere_data->sphere_local_pos_Y[mySphereID],
                                        sphere_data->sphere_local_pos_Z[mySphereID]);
         mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));
-        if ((cluster == 0) || (sphere_data->sphere_cluster[mySphereID] == cluster)) {
+        if ((cluster == static_cast<unsigned int>(CLUSTER_INDEX::NONE)) ||
+            (sphere_data->sphere_cluster[mySphereID] == cluster)) {
             if (mySphere_pos_global.z < z_lim) {
                 d_below[mySphereID] = true;
             }

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -143,7 +143,7 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
 
 // Find if any particle is in the volume cluster.
 // If any sphere in cluster sphere_type == VOLUME -> sphere_cluster = VOLUME
-// UNLESS it is the biggest cluster -> sphere_cluster = GROUND
+// UNLESS it is the biggestbiggest cluster -> sphere_cluster = GROUND
 static __global__ void FindVolumeCluster(unsigned int nSpheres,
                                          bool * visited,
                                          bool * in_volume,
@@ -359,9 +359,9 @@ __host__ void ConstructGraphByProximity(ChSystemGpu_impl::GranSphereDataPtr sphe
                                         size_t min_pts,
                                         float radius);
 
-__host__ void GdbscanSearchGraph(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
-                                 ChSystemGpu_impl::GranParamsPtr gran_params,
-                                 unsigned int nSpheres,
-                                 size_t min_pts);
+__host__ void GdbscanSearchGraphByBFS(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
+                                      ChSystemGpu_impl::GranParamsPtr gran_params,
+                                      unsigned int nSpheres,
+                                      size_t min_pts);
 
 /// @} gpu_cuda

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -133,13 +133,8 @@ static __global__ void AreSpheresBelowZLim(ChSystemGpu_impl::GranSphereDataPtr s
                                        sphere_data->sphere_local_pos_Y[mySphereID],
                                        sphere_data->sphere_local_pos_Z[mySphereID]);
         mySphere_pos_global = int64_t3_to_double3(convertPosLocalToGlobal(thisSD, mySphere_pos_local, gran_params));
-        // THIS POSITION IS WRONG FOR SOME REASON
 
-        /// if:
-        ///    cond 1-  cluster == NONE                -> check sphere
-        ///    cond 2-  sphere is in input cluster     -> check sphere
-        if ((cluster == static_cast<unsigned int>(CLUSTER_INDEX::NONE)) ||
-            (sphere_data->sphere_cluster[mySphereID] == cluster)) {
+        if (sphere_data->sphere_cluster[mySphereID] == cluster) {
             if ((mySphere_pos_global.z * LENGTH_SU2UU) < z_lim) {
                 d_below[mySphereID] = true;
             }

--- a/src/chrono_gpu/cuda/ChGpuClustering.cuh
+++ b/src/chrono_gpu/cuda/ChGpuClustering.cuh
@@ -350,6 +350,9 @@ static __global__ void ComputeAdjListByProximity(ChSystemGpu_impl::GranSphereDat
     assert(adjacency_num == sphere_data->adj_num[mySphereID]);
 }
 
+namespace chrono {
+namespace gpu {
+
 __host__ void ConstructGraphByContact(ChSystemGpu_impl::GranSphereDataPtr sphere_data,
                                       ChSystemGpu_impl::GranParamsPtr gran_params,
                                       unsigned int nSpheres);
@@ -376,5 +379,9 @@ __host__ void IdentifyVolumeCluster(ChSystemGpu_impl::GranSphereDataPtr sphere_d
                                     unsigned int ** h_clusters);
 
 __host__ void FreeClusters(unsigned int ** h_clusters);
+
+
+} //chrono
+} //gpu
 
 /// @} gpu_cuda

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -442,28 +442,9 @@ __host__ void ChSystemGpuMesh_impl::IdentifyClusters() {
         // step 2- Search the graph, find the clusters.
         switch (gran_params->cluster_search_method) {
             case CLUSTER_SEARCH_METHOD::BFS: {
-                /// sphere_type is CORE if neighbors_num > min_pts else NOISE
-                GdbscanInitSphereType<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
-                    nSpheres,
-                    sphere_data->adj_num,
-                    sphere_data->sphere_type,
-                    gran_params->gdbscan_min_pts);
-                gpuErrchk(cudaPeekAtLastError());
-                gpuErrchk(cudaDeviceSynchronize());
-
-                /// finds spheres in volume
-                /// must be set AFTER GdbscanInitSphereType,
-                ///  and AFTER interactionGranMat_TriangleSoup,
-                ///  which is AFTER AdvanceSimulation
-                SetVolumeSphereType<<<nBlocks, CUDA_THREADS_PER_BLOCK>>>(
-                    sphere_data,
-                    nSpheres);
-                gpuErrchk(cudaPeekAtLastError());
-                gpuErrchk(cudaDeviceSynchronize());
-
-                /// Finds clusters, tags Ground cluster (biggest), other clusters.
+                /// Finds clusters, tags Ground cluster, other clusters.
                 /// Changes NOISE sphere_type to BORDER if in cluster
-                GdbscanSearchGraph(sphere_data, gran_params, nSpheres,
+                GdbscanSearchGraphByBFS(sphere_data, gran_params, nSpheres,
                                    gran_params->gdbscan_min_pts);
                 break;
             }

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -449,6 +449,7 @@ __host__ void ChSystemGpuMesh_impl::IdentifyClusters() {
             default: {break;}
         }
         IdentifyGroundCluster(sphere_data, gran_params, nSpheres, h_clusters);
+        IdentifyVolumeCluster(sphere_data, gran_params, nSpheres, h_clusters);
         FreeClusters(h_clusters);
     } else {
         printf("ERROR: Either cluster_graph_method or cluster_search_method not set. Skipping clustering.\n");

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -442,8 +442,10 @@ __host__ void ChSystemGpuMesh_impl::IdentifyClusters() {
         // step 2- Search the graph, find the clusters.
         switch (gran_params->cluster_search_method) {
             case CLUSTER_SEARCH_METHOD::BFS: {
-                h_clusters = GdbscanSearchGraphByBFS(sphere_data, gran_params, nSpheres,
-                                   gran_params->gdbscan_min_pts);
+                h_clusters = GdbscanSearchGraphByBFS(sphere_data,
+                                                     gran_params,
+                                                     nSpheres,
+                                                     gran_params->gdbscan_min_pts);
                 break;
             }
             default: {break;}

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -442,15 +442,13 @@ __host__ void ChSystemGpuMesh_impl::IdentifyClusters() {
         // step 2- Search the graph, find the clusters.
         switch (gran_params->cluster_search_method) {
             case CLUSTER_SEARCH_METHOD::BFS: {
-                /// Finds clusters, tags Ground cluster, other clusters.
-                /// Changes NOISE sphere_type to BORDER if in cluster
                 h_clusters = GdbscanSearchGraphByBFS(sphere_data, gran_params, nSpheres,
                                    gran_params->gdbscan_min_pts);
                 break;
             }
             default: {break;}
         }
-        IdentifyGroundCluster(sphere_data, gran_params, nSpheres, h_clusters, LENGTH_SU2UU);
+        IdentifyGroundCluster(sphere_data, gran_params, nSpheres, h_clusters);
         FreeClusters(h_clusters);
     } else {
         printf("ERROR: Either cluster_graph_method or cluster_search_method not set. Skipping clustering.\n");

--- a/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
+++ b/src/chrono_gpu/cuda/ChGpu_SMC_trimesh.cu
@@ -425,6 +425,7 @@ __host__ void ChSystemGpuMesh_impl::IdentifyClusters() {
     if ((gran_params->cluster_graph_method > CLUSTER_GRAPH_METHOD::NONE)
         && (gran_params->cluster_search_method > CLUSTER_SEARCH_METHOD::NONE)) {
         // step 1- Graph construction
+        unsigned int ** h_clusters;
         switch (gran_params->cluster_graph_method) {
             case CLUSTER_GRAPH_METHOD::CONTACT: {
                 ConstructGraphByContact(sphere_data, gran_params, nSpheres);
@@ -438,18 +439,19 @@ __host__ void ChSystemGpuMesh_impl::IdentifyClusters() {
             }
             default: {break;}
         }
-
         // step 2- Search the graph, find the clusters.
         switch (gran_params->cluster_search_method) {
             case CLUSTER_SEARCH_METHOD::BFS: {
                 /// Finds clusters, tags Ground cluster, other clusters.
                 /// Changes NOISE sphere_type to BORDER if in cluster
-                GdbscanSearchGraphByBFS(sphere_data, gran_params, nSpheres,
+                h_clusters = GdbscanSearchGraphByBFS(sphere_data, gran_params, nSpheres,
                                    gran_params->gdbscan_min_pts);
                 break;
             }
             default: {break;}
         }
+        IdentifyGroundCluster(sphere_data, gran_params, nSpheres, h_clusters, LENGTH_SU2UU);
+        FreeClusters(h_clusters);
     } else {
         printf("ERROR: Either cluster_graph_method or cluster_search_method not set. Skipping clustering.\n");
     }

--- a/src/chrono_gpu/physics/ChSystemGpu.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu.cpp
@@ -72,6 +72,14 @@ void ChSystemGpu::SetClusterGraphMethod(CLUSTER_GRAPH_METHOD flag) {
     m_sys->gran_params->cluster_graph_method = flag;
 }
 
+void ChSystemGpu::SetClusterGroundMethod(CLUSTER_GROUND_METHOD flag) {
+    m_sys->gran_params->cluster_ground_method = flag;
+}
+
+void ChSystemGpu::SetClusterGroundZLim(float z_lim) {
+    m_sys->gran_params->ground_z_lim = z_lim;
+}
+
 void ChSystemGpu::SetFixedStepSize(float size_UU) {
     m_sys->stepSize_UU = size_UU;
 }

--- a/src/chrono_gpu/physics/ChSystemGpu.h
+++ b/src/chrono_gpu/physics/ChSystemGpu.h
@@ -69,7 +69,7 @@ class CH_GPU_API ChSystemGpu {
     void SetClusterGraphMethod(CLUSTER_GRAPH_METHOD flag);
     void SetClusterSearchMethod(CLUSTER_SEARCH_METHOD flag);
     void SetClusterGroundMethod(CLUSTER_GROUND_METHOD flag);
-    void SetClusterGroundZlim(float z_lim); // for CLUSTER_GROUND_METHOD::LOWEST
+    void SetClusterGroundZLim(float z_lim); // for CLUSTER_GROUND_METHOD::LOWEST
 
     /// Set timestep size.
     void SetFixedStepSize(float size_UU);

--- a/src/chrono_gpu/physics/ChSystemGpu.h
+++ b/src/chrono_gpu/physics/ChSystemGpu.h
@@ -68,6 +68,8 @@ class CH_GPU_API ChSystemGpu {
     /// Set graph construction method in gran_params with a CLUSTER_GRAPH_METHOD
     void SetClusterGraphMethod(CLUSTER_GRAPH_METHOD flag);
     void SetClusterSearchMethod(CLUSTER_SEARCH_METHOD flag);
+    void SetClusterGroundMethod(CLUSTER_GROUND_METHOD flag);
+    void SetClusterGroundZlim(float z_lim); // for CLUSTER_GROUND_METHOD::LOWEST
 
     /// Set timestep size.
     void SetFixedStepSize(float size_UU);

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -77,7 +77,7 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
 
     gran_params->cluster_graph_method = CLUSTER_GRAPH_METHOD::CONTACT;
     gran_params->cluster_search_method = CLUSTER_SEARCH_METHOD::BFS;
-    gran_params->cluster_ground_method = CLUSTER_GROUND_METHOD::BIGGEST;
+    gran_params->cluster_ground_method = CLUSTER_GROUND_METHOD::LOWEST;
 
     gran_params->gdbscan_radius = 0.1f; // [m] ?
     gran_params->gdbscan_min_pts = 3;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -81,6 +81,7 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
 
     gran_params->gdbscan_radius = 0.1f; // [m] ?
     gran_params->gdbscan_min_pts = 3;
+    gran_params->ground_z_lim = - box_size_Z / 2.0f + sphere_rad;
 
     this->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
     this->output_flags = ABSV | ANG_VEL_COMPONENTS | CLUSTER | ADJACENCY;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -77,7 +77,7 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
 
     gran_params->cluster_graph_method = CLUSTER_GRAPH_METHOD::CONTACT;
     gran_params->cluster_search_method = CLUSTER_SEARCH_METHOD::BFS;
-    gran_params->cluster_ground_method = CLUSTER_GROUND_METHOD::LOWEST;
+    gran_params->cluster_ground_method = CLUSTER_GROUND_METHOD::BIGGEST;
 
     gran_params->gdbscan_radius = 0.1f; // [m] ?
     gran_params->gdbscan_min_pts = 3;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -81,7 +81,8 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
 
     gran_params->gdbscan_radius = 0.1f; // [m] ?
     gran_params->gdbscan_min_pts = 3;
-    gran_params->ground_z_lim = - box_size_Z / 2.0f + sphere_rad;
+    gran_params->ground_z_lim = - box_size_Z / 2.0f + sphere_rad; 
+    // any sphere below this z-plane makes its cluster GROUND 
 
     this->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
     this->output_flags = ABSV | ANG_VEL_COMPONENTS | CLUSTER | ADJACENCY;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -77,6 +77,7 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
 
     gran_params->cluster_graph_method = CLUSTER_GRAPH_METHOD::CONTACT;
     gran_params->cluster_search_method = CLUSTER_SEARCH_METHOD::BFS;
+    gran_params->cluster_ground_method = CLUSTER_GROUND_METHOD::LOWEST;
 
     gran_params->gdbscan_radius = 0.1f; // [m] ?
     gran_params->gdbscan_min_pts = 3;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -77,7 +77,7 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
 
     gran_params->cluster_graph_method = CLUSTER_GRAPH_METHOD::CONTACT;
     gran_params->cluster_search_method = CLUSTER_SEARCH_METHOD::BFS;
-    gran_params->cluster_ground_method = CLUSTER_GROUND_METHOD::LOWEST;
+    gran_params->cluster_ground_method = CLUSTER_GROUND_METHOD::BIGGEST;
 
     gran_params->gdbscan_radius = 0.1f;  // [m] ?
     gran_params->gdbscan_min_pts = 3;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -103,7 +103,6 @@ void ChSystemGpu_impl::CreateWallBCs() {
     float plane_center_top_Y[3] = {0, box_size_Y / 2, 0};
     float plane_center_bot_Z[3] = {0, 0, -box_size_Z / 2};
     float plane_center_top_Z[3] = {0, 0, box_size_Z / 2};
-
     // face in upwards
     float plane_normal_bot_X[3] = {1, 0, 0};
     float plane_normal_top_X[3] = {-1, 0, 0};

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -81,7 +81,7 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
 
     gran_params->gdbscan_radius = 0.1f; // [m] ?
     gran_params->gdbscan_min_pts = 3;
-    gran_params->ground_z_lim = - box_size_Z / 2.0f + sphere_rad; 
+    gran_params->ground_z_lim = -box_size_Z / 2.0f + sphere_rad; 
     // any sphere below this z-plane makes its cluster GROUND 
 
     this->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.cpp
@@ -79,10 +79,10 @@ ChSystemGpu_impl::ChSystemGpu_impl(float sphere_rad, float density, float3 boxDi
     gran_params->cluster_search_method = CLUSTER_SEARCH_METHOD::BFS;
     gran_params->cluster_ground_method = CLUSTER_GROUND_METHOD::LOWEST;
 
-    gran_params->gdbscan_radius = 0.1f; // [m] ?
+    gran_params->gdbscan_radius = 0.1f;  // [m] ?
     gran_params->gdbscan_min_pts = 3;
-    gran_params->ground_z_lim = -box_size_Z / 2.0f + sphere_rad; 
-    // any sphere below this z-plane makes its cluster GROUND 
+    // any sphere below this z-plane makes its cluster GROUND
+    gran_params->ground_z_lim = -(box_size_Z / 2.0f) + sphere_rad;
 
     this->time_integrator = CHGPU_TIME_INTEGRATOR::EXTENDED_TAYLOR;
     this->output_flags = ABSV | ANG_VEL_COMPONENTS | CLUSTER | ADJACENCY;
@@ -103,6 +103,7 @@ void ChSystemGpu_impl::CreateWallBCs() {
     float plane_center_top_Y[3] = {0, box_size_Y / 2, 0};
     float plane_center_bot_Z[3] = {0, 0, -box_size_Z / 2};
     float plane_center_top_Z[3] = {0, 0, box_size_Z / 2};
+
     // face in upwards
     float plane_normal_bot_X[3] = {1, 0, 0};
     float plane_normal_top_X[3] = {-1, 0, 0};

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -103,6 +103,7 @@ class ChSystemGpu_impl {
         
         CLUSTER_GRAPH_METHOD cluster_graph_method; /// graph construction for clustering
         CLUSTER_SEARCH_METHOD cluster_search_method; /// search algorithm used for clustering
+        CLUSTER_GROUND_METHOD cluster_ground_method; /// identification method of ground cluster
 
         /// Ratio of normal force to peak tangent force, also arctan(theta) where theta is the friction angle
         /// sphere-to-sphere

--- a/src/chrono_gpu/physics/ChSystemGpu_impl.h
+++ b/src/chrono_gpu/physics/ChSystemGpu_impl.h
@@ -176,6 +176,10 @@ class ChSystemGpu_impl {
         // GDBSCAN clustering parameters.
         float gdbscan_radius; // ignored if CLUSTER_GRAPH_METHOD::CONTACT
         unsigned int gdbscan_min_pts; // used if CLUSTER_GRAPH_METHOD::CONTACT
+
+        // Clustering GROUND identification parameters
+        // Any cluster that has a sphere below this value is the ground.
+        float ground_z_lim; // for CLUSTER_GROUND_METHOD::LOWEST
     };
 
     /// Structure of pointers to kinematic quantities of the ChSystemGpu_impl.


### PR DESCRIPTION
The `GROUND` cluster is currently identified by finding the cluster with the most spheres using the array of array `h_clusters`. This is suitable in most cases, but there are some edge cases where lots of digging occurs where this can not be the case, and the `GROUND` cluster would be incorrectly tagged.

Another method based around finding the cluster closest to the bottom of the bounding box should be implemented.

Then, it should be possible to switch between these methods by using the `CLUSTER_GROUND_METHOD` switch with `BIGGEST` and `LOWEST` settings.
The new `LOWEST` method tags any cluster that has spheres below a certain value to `GROUND`. This value can be set by the user, but by default it uses the bottom of the bounding box + the sphere diameter.